### PR TITLE
Week 5: Events, Market Feed, Concierge, Account Portal

### DIFF
--- a/app/account/account-portal.tsx
+++ b/app/account/account-portal.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ProfileForm } from "./profile-form";
+import {
+  MOCK_ARTICLES,
+  MOCK_EVENTS,
+  type MockArticle,
+  type MockEvent,
+} from "@/app/lib/mock-data";
+import { EventCard } from "@/app/components/events/event-card";
+import { cn } from "@/app/lib/cn";
+
+const TABS = [
+  { id: "saved", label: "Saved Insights" },
+  { id: "events", label: "My Events" },
+  { id: "requests", label: "Concierge Requests" },
+  { id: "alerts", label: "Alerts" },
+  { id: "profile", label: "Profile" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
+/* Mocked user state — wire to real backend later */
+const SAVED_ARTICLE_SLUGS = [
+  "mongolia-banking-sector-q1-2026-earnings-review",
+  "mongolia-dealbook-2025",
+  "tsetsens-mining-300m-bond",
+];
+
+const REGISTERED_EVENT_SLUGS = ["mif-2026", "cmm-investor-day-spring-2026"];
+
+const MOCK_REQUESTS = [
+  {
+    id: "r-001",
+    summary: "Investor introduction — Singapore credit funds active in Mongolian banks",
+    type: "investor-intro",
+    submittedAt: "2026-04-22",
+    status: "in-progress",
+    assignee: "Namkhaidorj B.",
+  },
+  {
+    id: "r-002",
+    summary: "Custom research — Mongolian renewable energy IPP pipeline",
+    type: "research-request",
+    submittedAt: "2026-04-09",
+    status: "delivered",
+    assignee: "Enkhjin A.",
+  },
+];
+
+const MOCK_ALERTS_STATUS = {
+  enabled: false,
+};
+
+export function AccountPortal() {
+  const [tab, setTab] = useState<TabId>("saved");
+
+  const savedArticles = MOCK_ARTICLES.filter((a) =>
+    SAVED_ARTICLE_SLUGS.includes(a.slug)
+  );
+  const registeredEvents = MOCK_EVENTS.filter((e) =>
+    REGISTERED_EVENT_SLUGS.includes(e.slug)
+  ).sort((a, b) => +new Date(a.startDate) - +new Date(b.startDate));
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[220px_1fr] gap-8">
+      {/* Sidebar nav */}
+      <aside className="flex flex-col gap-1 lg:sticky lg:top-[calc(var(--header-h)+24px)] self-start">
+        <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-2 px-2">
+          Account
+        </div>
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={cn(
+              "text-left px-3 py-2 rounded-[var(--btn-r)] text-sm font-medium cursor-pointer transition-colors border-none",
+              tab === t.id
+                ? "bg-brand-m text-brand font-semibold"
+                : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg"
+            )}
+          >
+            {t.label}
+          </button>
+        ))}
+      </aside>
+
+      {/* Tab content */}
+      <div className="min-w-0">
+        {tab === "saved" && <SavedTab articles={savedArticles} />}
+        {tab === "events" && <EventsTab events={registeredEvents} />}
+        {tab === "requests" && <RequestsTab />}
+        {tab === "alerts" && <AlertsTab />}
+        {tab === "profile" && <ProfileTab />}
+      </div>
+    </div>
+  );
+}
+
+/* ── Saved Insights ─────────────────────────────────── */
+
+function SavedTab({ articles }: { articles: MockArticle[] }) {
+  if (articles.length === 0) {
+    return (
+      <Empty
+        title="No saved insights yet"
+        body="Hit the bookmark icon on any article to save it for later."
+        cta={{ label: "Browse Insights", href: "/insights" }}
+      />
+    );
+  }
+  return (
+    <div>
+      <SectionHeader
+        title="Saved Insights"
+        subtitle={`${articles.length} saved`}
+      />
+      <div className="flex flex-col gap-3">
+        {articles.map((a) => (
+          <Link
+            key={a.slug}
+            href={`/insights/${a.slug}`}
+            className="card flex items-start gap-4 no-underline group"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="font-mono text-[10px] uppercase tracking-badge text-brand">
+                  {a.contentType.replace("-", " ")}
+                </span>
+                <span className="font-mono text-[10px] text-fg-3">
+                  {new Date(a.publishedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                </span>
+              </div>
+              <h3 className="font-display font-bold text-sm leading-[1.3] mb-1 group-hover:text-brand transition-colors">
+                {a.title}
+              </h3>
+              <p className="text-xs text-fg-2 leading-[1.5] line-clamp-2">
+                {a.excerpt}
+              </p>
+              <div className="text-[11px] text-fg-3 mt-2">
+                {a.author} · {a.readTime} min read
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Registered Events ──────────────────────────────── */
+
+function EventsTab({ events }: { events: MockEvent[] }) {
+  const upcoming = events.filter((e) => e.status !== "past");
+  const past = events.filter((e) => e.status === "past");
+
+  if (events.length === 0) {
+    return (
+      <Empty
+        title="No registered events"
+        body="Register for upcoming forums and briefings to track them here."
+        cta={{ label: "See upcoming events", href: "/events" }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <SectionHeader
+          title="My Events"
+          subtitle={`${events.length} registered`}
+        />
+        {upcoming.length > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {upcoming.map((e) => (
+              <EventCard key={e.slug} event={e} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {past.length > 0 && (
+        <div>
+          <SectionHeader title="Past attended" />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {past.map((e) => (
+              <EventCard key={e.slug} event={e} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Concierge Requests ─────────────────────────────── */
+
+const REQUEST_STATUS_LABEL: Record<string, { label: string; tone: "signal" | "pos" | "fg" }> = {
+  "in-progress": { label: "In Progress", tone: "signal" },
+  delivered: { label: "Delivered", tone: "pos" },
+  closed: { label: "Closed", tone: "fg" },
+};
+
+function RequestsTab() {
+  if (MOCK_REQUESTS.length === 0) {
+    return (
+      <Empty
+        title="No concierge requests"
+        body="Get curated investor introductions, deal flow, or custom research."
+        cta={{ label: "Open a request", href: "/concierge" }}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <SectionHeader title="Concierge Requests" subtitle={`${MOCK_REQUESTS.length} active`} action={{ label: "New request", href: "/concierge" }} />
+      <div className="flex flex-col gap-3">
+        {MOCK_REQUESTS.map((r) => {
+          const status = REQUEST_STATUS_LABEL[r.status] ?? REQUEST_STATUS_LABEL.closed;
+          return (
+            <div key={r.id} className="card flex flex-col gap-3">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span
+                  className={cn(
+                    "inline-flex items-center font-mono uppercase font-semibold tracking-badge rounded-[var(--btn-r)] text-[10px] px-2 py-0.5",
+                    status.tone === "signal" && "bg-[var(--signal-m)] text-[color:var(--signal-h)]",
+                    status.tone === "pos" && "bg-[var(--pos-m)] text-[color:var(--pos-t)]",
+                    status.tone === "fg" && "bg-surface text-fg-2"
+                  )}
+                >
+                  {status.label}
+                </span>
+                <span className="font-mono text-[10px] uppercase tracking-badge text-fg-3">
+                  {r.type.replace("-", " ")}
+                </span>
+                <span className="ml-auto font-mono text-[10px] text-fg-3">
+                  Submitted {new Date(r.submittedAt).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                </span>
+              </div>
+              <h3 className="font-display font-bold text-sm leading-[1.35]">
+                {r.summary}
+              </h3>
+              <div className="text-[11px] text-fg-3 mt-auto pt-2 border-t border-border-s">
+                Assigned to <span className="text-fg-2 font-semibold">{r.assignee}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ── Alerts (v2 placeholder) ────────────────────────── */
+
+function AlertsTab() {
+  if (!MOCK_ALERTS_STATUS.enabled) {
+    return (
+      <div className="card !p-8 text-center flex flex-col items-center gap-3 max-w-[480px] mx-auto">
+        <div className="w-10 h-10 rounded-full bg-brand-m grid place-items-center">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--brand)" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+            <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+          </svg>
+        </div>
+        <div>
+          <div className="font-display font-extrabold text-base mb-1">
+            Alerts coming in v2
+          </div>
+          <p className="text-sm text-fg-2 leading-[1.55]">
+            Watchlists, custom alerts, and email digests are part of the next release. Existing paid members will get early access.
+          </p>
+        </div>
+      </div>
+    );
+  }
+  return null;
+}
+
+/* ── Profile ────────────────────────────────────────── */
+
+function ProfileTab() {
+  return (
+    <div>
+      <SectionHeader title="Profile" subtitle="ganerdene.dev@gmail.com" />
+      <div className="max-w-[520px]">
+        <ProfileForm />
+      </div>
+    </div>
+  );
+}
+
+/* ── Section helpers ────────────────────────────────── */
+
+function SectionHeader({
+  title,
+  subtitle,
+  action,
+}: {
+  title: string;
+  subtitle?: string;
+  action?: { label: string; href: string };
+}) {
+  return (
+    <div className="flex items-baseline gap-3 mb-4">
+      <h2 className="font-display font-extrabold text-md tracking-tight">
+        {title}
+      </h2>
+      {subtitle && (
+        <span className="font-mono text-[11px] uppercase tracking-badge text-fg-3">
+          {subtitle}
+        </span>
+      )}
+      {action && (
+        <Link
+          href={action.href}
+          className="ml-auto text-sm font-display font-semibold text-brand hover:text-brand-h no-underline"
+        >
+          {action.label} →
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function Empty({
+  title,
+  body,
+  cta,
+}: {
+  title: string;
+  body: string;
+  cta: { label: string; href: string };
+}) {
+  return (
+    <div className="card !p-8 text-center flex flex-col items-center gap-3 max-w-[480px] mx-auto">
+      <div className="font-display font-extrabold text-base">{title}</div>
+      <p className="text-sm text-fg-2 leading-[1.55]">{body}</p>
+      <Link href={cta.href} className="btn btn-primary text-sm mt-2">
+        {cta.label}
+      </Link>
+    </div>
+  );
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,33 +1,29 @@
 import type { Metadata } from "next";
-import { ProfileForm } from "./profile-form";
+import { AccountPortal } from "./account-portal";
 
 export const metadata: Metadata = {
   title: "My Account — MarketIQ",
-  description: "Manage your MarketIQ profile and preferences.",
+  description: "Saved insights, registered events, concierge requests, and profile.",
 };
 
 export default function AccountPage() {
   return (
-    <div className="content-max py-10">
-      {/* Email bar */}
-      <div className="text-center py-3 px-4 bg-surface rounded-[var(--card-r)] border border-border-s mb-8">
-        <span className="font-mono text-xs text-fg-2 tracking-wide uppercase">
-          ganerdene.dev@gmail.com
-        </span>
-      </div>
-
-      <div className="max-w-[520px] mx-auto">
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="font-display font-extrabold text-xl tracking-tight">
-            My Profile
+    <div className="content-max px-6 pb-16">
+      <div className="pt-8 pb-6 flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <div className="font-mono text-[11px] uppercase tracking-badge text-brand mb-2">
+            My Account
+          </div>
+          <h1 className="font-display font-extrabold text-2xl tracking-tight leading-heading">
+            ganerdene.dev@gmail.com
           </h1>
-          <button className="text-sm text-brand-l font-medium hover:text-brand cursor-pointer bg-transparent border-none">
-            Sign Out
-          </button>
         </div>
-
-        <ProfileForm />
+        <button className="text-sm text-fg-3 font-medium hover:text-brand cursor-pointer bg-transparent border-none">
+          Sign Out
+        </button>
       </div>
+
+      <AccountPortal />
     </div>
   );
 }

--- a/app/components/events/event-card.tsx
+++ b/app/components/events/event-card.tsx
@@ -1,0 +1,205 @@
+import Link from "next/link";
+import type { MockEvent } from "@/app/lib/mock-data";
+import { cn } from "@/app/lib/cn";
+
+const STATUS_LABEL: Record<MockEvent["status"], { label: string; tone: "signal" | "pos" | "neg" | "fg" }> = {
+  upcoming: { label: "Upcoming", tone: "signal" },
+  "registration-open": { label: "Registration Open", tone: "pos" },
+  "sold-out": { label: "Sold Out", tone: "neg" },
+  past: { label: "Past Event", tone: "fg" },
+};
+
+const FORMAT_LABEL: Record<MockEvent["format"], string> = {
+  "in-person": "In Person",
+  virtual: "Virtual",
+  hybrid: "Hybrid",
+};
+
+function formatDateRange(start: string, end?: string): string {
+  const s = new Date(start);
+  const monthShort = (d: Date) => d.toLocaleDateString("en-US", { month: "short" });
+  const day = (d: Date) => d.getDate();
+  const year = (d: Date) => d.getFullYear();
+
+  if (!end) {
+    return `${monthShort(s)} ${day(s)}, ${year(s)}`;
+  }
+  const e = new Date(end);
+  const sameMonth = s.getMonth() === e.getMonth() && s.getFullYear() === e.getFullYear();
+  if (sameMonth) {
+    return `${monthShort(s)} ${day(s)}–${day(e)}, ${year(s)}`;
+  }
+  return `${monthShort(s)} ${day(s)} – ${monthShort(e)} ${day(e)}, ${year(e)}`;
+}
+
+interface EventCardProps {
+  event: MockEvent;
+  variant?: "default" | "featured" | "compact";
+}
+
+export function EventCard({ event, variant = "default" }: EventCardProps) {
+  const status = STATUS_LABEL[event.status];
+
+  if (variant === "featured") {
+    return (
+      <Link
+        href={`/events/${event.slug}`}
+        className="card block no-underline !p-0 overflow-hidden h-full flex flex-col group"
+      >
+        <div
+          className="relative aspect-[16/8] w-full shrink-0 bg-gradient-to-br from-brand to-brand-l"
+          style={{ borderBottom: "1px solid var(--border-s)" }}
+        >
+          <div className="absolute inset-0 flex items-end p-6">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-badge text-white/80 mb-2">
+                {FORMAT_LABEL[event.format]}
+              </div>
+              <div className="font-display text-3xl font-extrabold text-white leading-[1.1] tracking-tight max-sm:text-2xl">
+                {event.shortName ?? event.title}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="p-6 sm:p-7 flex flex-col gap-3 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <StatusBadge status={status} />
+            <span className="font-mono text-[11px] text-fg-3">
+              {formatDateRange(event.startDate, event.endDate)}
+            </span>
+          </div>
+          <h2 className="font-display text-xl font-extrabold leading-[1.2] tracking-tight">
+            {event.title}
+          </h2>
+          <p className="text-sm text-fg-2 leading-[1.5] line-clamp-3">
+            {event.description}
+          </p>
+          <div className="text-xs text-fg-3 leading-relaxed">
+            {event.location}
+          </div>
+          {(event.expectedAttendees || event.presentingCompanies) && (
+            <div className="flex items-center gap-4 text-xs text-fg-2 mt-1">
+              {event.expectedAttendees && (
+                <span>
+                  <span className="font-display font-bold text-fg">{event.expectedAttendees}+</span> attendees
+                </span>
+              )}
+              {event.presentingCompanies && (
+                <span>
+                  <span className="font-display font-bold text-fg">{event.presentingCompanies}</span> presenting
+                </span>
+              )}
+            </div>
+          )}
+          <div className="mt-auto pt-3">
+            <span className="btn btn-primary text-sm w-full justify-center">
+              View Details
+            </span>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  if (variant === "compact") {
+    return (
+      <Link
+        href={`/events/${event.slug}`}
+        className="card flex items-start gap-4 no-underline group"
+      >
+        <DateBlock startDate={event.startDate} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <StatusBadge status={status} size="xs" />
+            <span className="font-mono text-[10px] text-fg-3">
+              {FORMAT_LABEL[event.format]}
+            </span>
+          </div>
+          <h3 className="font-display font-bold text-sm leading-[1.3] mb-1 group-hover:text-brand transition-colors">
+            {event.title}
+          </h3>
+          <div className="text-[11px] text-fg-3">
+            {event.location}
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href={`/events/${event.slug}`}
+      className="card flex flex-col no-underline overflow-hidden min-w-0 group"
+    >
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <StatusBadge status={status} />
+        <span className="font-mono text-[10px] uppercase tracking-badge text-fg-3">
+          {FORMAT_LABEL[event.format]}
+        </span>
+      </div>
+      <h3 className="font-display text-base font-bold leading-[1.3] tracking-tight mb-2 group-hover:text-brand transition-colors">
+        {event.title}
+      </h3>
+      <p className="text-sm text-fg-2 leading-[1.55] line-clamp-2 mb-4">
+        {event.tagline}
+      </p>
+      <div className="mt-auto pt-3 border-t border-border-s flex flex-col gap-1">
+        <div className="font-mono text-[11px] text-fg font-medium">
+          {formatDateRange(event.startDate, event.endDate)}
+        </div>
+        <div className="text-[11px] text-fg-3 truncate">
+          {event.location}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function StatusBadge({
+  status,
+  size = "sm",
+}: {
+  status: { label: string; tone: "signal" | "pos" | "neg" | "fg" };
+  size?: "xs" | "sm";
+}) {
+  const toneClass =
+    status.tone === "signal"
+      ? "bg-[var(--signal-m)] text-[color:var(--signal-h)]"
+      : status.tone === "pos"
+      ? "bg-[var(--pos-m)] text-[color:var(--pos-t)]"
+      : status.tone === "neg"
+      ? "bg-[var(--neg-m)] text-[color:var(--neg-t)]"
+      : "bg-surface text-fg-2";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center font-mono uppercase font-semibold tracking-badge rounded-[var(--btn-r)]",
+        toneClass,
+        size === "xs" ? "text-[9px] px-1.5 py-0.5" : "text-[10px] px-2 py-0.5"
+      )}
+    >
+      {status.label}
+    </span>
+  );
+}
+
+function DateBlock({ startDate }: { startDate: string }) {
+  const d = new Date(startDate);
+  const month = d.toLocaleDateString("en-US", { month: "short" }).toUpperCase();
+  const day = d.getDate();
+  return (
+    <div
+      className="shrink-0 w-[52px] text-center rounded-[var(--card-r)] border border-border-s bg-surface-down py-1.5"
+      aria-hidden
+    >
+      <div className="font-mono text-[10px] font-semibold tracking-badge text-brand">
+        {month}
+      </div>
+      <div className="font-display text-lg font-extrabold leading-none mt-0.5">
+        {day}
+      </div>
+    </div>
+  );
+}
+
+export { formatDateRange, FORMAT_LABEL, STATUS_LABEL };

--- a/app/components/events/registration-form.tsx
+++ b/app/components/events/registration-form.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/app/lib/cn";
+
+interface RegistrationFormProps {
+  eventTitle: string;
+  ticketPrice?: string;
+  registrationDeadline?: string;
+}
+
+const ATTENDANCE_TYPES = [
+  { value: "in-person", label: "In Person" },
+  { value: "virtual", label: "Virtual" },
+];
+
+export function RegistrationForm({
+  eventTitle,
+  ticketPrice,
+  registrationDeadline,
+}: RegistrationFormProps) {
+  const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [attendance, setAttendance] = useState("in-person");
+
+  function handleSubmit(e: { preventDefault: () => void }) {
+    e.preventDefault();
+    setSubmitting(true);
+    setTimeout(() => {
+      setSubmitting(false);
+      setSubmitted(true);
+    }, 700);
+  }
+
+  if (submitted) {
+    return (
+      <div className="card !p-6 flex flex-col gap-3">
+        <div className="w-10 h-10 rounded-full bg-pos-m grid place-items-center">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pos-t)" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </div>
+        <div>
+          <div className="font-display font-extrabold text-base mb-1">
+            You&apos;re registered.
+          </div>
+          <p className="text-sm text-fg-2 leading-[1.5]">
+            We sent a confirmation to your email with the event brief and access details. CMM concierge will reach out 48 hours before {eventTitle}.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="card !p-6 flex flex-col gap-4">
+      <div>
+        <div className="font-display font-extrabold text-base mb-1">
+          Reserve your spot
+        </div>
+        {ticketPrice && (
+          <div className="font-mono text-[11px] uppercase tracking-badge text-fg-3">
+            {ticketPrice}
+            {registrationDeadline && (
+              <>
+                {" · Closes "}
+                {new Date(registrationDeadline).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      <Field label="Full name" name="name" required />
+      <Field label="Work email" name="email" type="email" required />
+      <Field label="Company / Firm" name="company" required />
+      <Field label="Title" name="title" />
+
+      <div>
+        <label className="block font-display font-semibold text-xs uppercase tracking-[0.08em] text-fg-3 mb-2">
+          Attendance
+        </label>
+        <div className="flex gap-2">
+          {ATTENDANCE_TYPES.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setAttendance(opt.value)}
+              className={cn(
+                "flex-1 px-3 py-2 rounded-[var(--btn-r)] text-sm font-medium border cursor-pointer transition-all",
+                attendance === opt.value
+                  ? "border-brand bg-brand-m text-brand font-semibold"
+                  : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l"
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Field
+        label="Anything we should know?"
+        name="notes"
+        textarea
+        placeholder="Dietary restrictions, accessibility, or topics you'd want to discuss 1:1."
+      />
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="btn btn-primary w-full justify-center"
+      >
+        {submitting ? "Submitting…" : "Complete Registration"}
+      </button>
+
+      <p className="text-[11px] text-fg-3 leading-[1.5]">
+        By registering you agree to CMM&apos;s code of conduct and event policies.
+      </p>
+    </form>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  name: string;
+  type?: string;
+  required?: boolean;
+  textarea?: boolean;
+  placeholder?: string;
+}
+
+function Field({ label, name, type = "text", required, textarea, placeholder }: FieldProps) {
+  const baseCls =
+    "w-full px-3 py-2 bg-[var(--white)] border border-border rounded-[var(--btn-r)] text-sm text-fg placeholder:text-fg-3 focus:outline-none focus:border-brand-l transition-colors";
+
+  return (
+    <label className="block">
+      <span className="block font-display font-semibold text-xs uppercase tracking-[0.08em] text-fg-3 mb-1.5">
+        {label}
+        {required && <span className="text-brand ml-0.5">*</span>}
+      </span>
+      {textarea ? (
+        <textarea
+          name={name}
+          required={required}
+          placeholder={placeholder}
+          rows={3}
+          className={cn(baseCls, "resize-none leading-[1.5]")}
+        />
+      ) : (
+        <input
+          type={type}
+          name={name}
+          required={required}
+          placeholder={placeholder}
+          className={baseCls}
+        />
+      )}
+    </label>
+  );
+}

--- a/app/components/events/speaker-card.tsx
+++ b/app/components/events/speaker-card.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import type { MockSpeaker } from "@/app/lib/mock-data";
+
+interface SpeakerCardProps {
+  speaker: MockSpeaker;
+  size?: "sm" | "md";
+}
+
+export function SpeakerCard({ speaker, size = "md" }: SpeakerCardProps) {
+  const isSm = size === "sm";
+  return (
+    <Link
+      href={`/events/speakers/${speaker.slug}`}
+      className="card flex items-start gap-3 no-underline group"
+    >
+      <Avatar speaker={speaker} size={isSm ? "sm" : "md"} />
+      <div className="flex-1 min-w-0">
+        <div className="font-display font-bold text-sm leading-[1.25] group-hover:text-brand transition-colors">
+          {speaker.name}
+        </div>
+        <div className="text-[11px] text-fg-2 mt-0.5 leading-[1.4]">
+          {speaker.title}
+        </div>
+        <div className="text-[11px] text-fg-3 mt-0.5">
+          {speaker.org}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export function Avatar({
+  speaker,
+  size = "md",
+}: {
+  speaker: Pick<MockSpeaker, "initials" | "name" | "photo">;
+  size?: "sm" | "md" | "lg";
+}) {
+  const dim = size === "sm" ? "w-9 h-9 text-[11px]" : size === "lg" ? "w-16 h-16 text-base" : "w-11 h-11 text-xs";
+  return (
+    <div
+      className={`shrink-0 ${dim} rounded-full bg-brand-m text-brand font-display font-bold grid place-items-center`}
+      aria-label={speaker.name}
+    >
+      {speaker.initials}
+    </div>
+  );
+}

--- a/app/components/feed/entity-news-widget.tsx
+++ b/app/components/feed/entity-news-widget.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { MOCK_NEWS } from "@/app/lib/mock-data";
+import { NewsItemCard } from "@/app/components/feed/news-item-card";
+
+interface EntityNewsWidgetProps {
+  entitySlug: string;
+  limit?: number;
+  title?: string;
+}
+
+export function EntityNewsWidget({
+  entitySlug,
+  limit = 5,
+  title = "In the news",
+}: EntityNewsWidgetProps) {
+  const items = MOCK_NEWS.filter((n) => n.entitySlugs.includes(entitySlug))
+    .sort((a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt))
+    .slice(0, limit);
+
+  if (items.length === 0) {
+    return (
+      <div className="widget">
+        <div className="widget-header">
+          <span>{title}</span>
+        </div>
+        <div className="widget-body">
+          <p className="text-sm text-fg-3 leading-[1.5]">
+            No recent news matched to this entity.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="widget">
+      <div className="widget-header">
+        <span>{title}</span>
+        <Link
+          href={`/feed?entity=${entitySlug}`}
+          className="font-mono text-[10px] uppercase tracking-badge text-brand hover:text-brand-h no-underline"
+        >
+          See all →
+        </Link>
+      </div>
+      <div>
+        {items.map((item) => (
+          <NewsItemCard key={item.id} item={item} variant="inline" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/feed/news-item-card.tsx
+++ b/app/components/feed/news-item-card.tsx
@@ -1,0 +1,199 @@
+import Link from "next/link";
+import {
+  type MockNewsItem,
+  MOCK_ENTITIES,
+  NEWS_CATEGORY_COLORS,
+  NEWS_CATEGORY_LABELS,
+} from "@/app/lib/mock-data";
+import { cn } from "@/app/lib/cn";
+
+interface NewsItemCardProps {
+  item: MockNewsItem;
+  variant?: "default" | "compact" | "inline";
+  showCategory?: boolean;
+  showEntities?: boolean;
+}
+
+function relativeTime(iso: string): string {
+  const now = Date.now();
+  const t = new Date(iso).getTime();
+  const diff = Math.max(0, now - t);
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function NewsItemCard({
+  item,
+  variant = "default",
+  showCategory = true,
+  showEntities = true,
+}: NewsItemCardProps) {
+  const entityRefs = item.entitySlugs
+    .map((slug) => MOCK_ENTITIES.find((e) => e.slug === slug))
+    .filter((e): e is NonNullable<typeof e> => Boolean(e));
+
+  const lowConfidence = item.confidence < 0.75;
+  const categoryColor = NEWS_CATEGORY_COLORS[item.category];
+
+  const detailHref = `/feed/${item.id}`;
+
+  if (variant === "inline") {
+    return (
+      <Link
+        href={detailHref}
+        className="block no-underline group border-b border-border-s last:border-b-0 hover:bg-brand-m transition-colors"
+      >
+        <article className="px-5 py-3.5">
+          <div className="flex items-center gap-2 mb-1.5">
+            <CategoryDot color={categoryColor} />
+            <span className="font-mono text-[10px] uppercase tracking-badge text-fg-3">
+              {NEWS_CATEGORY_LABELS[item.category]}
+            </span>
+            {item.isBreaking && <BreakingBadge />}
+            {lowConfidence && <LowConfidenceBadge />}
+          </div>
+          <h3 className="line-clamp-2 font-display text-[13px] font-semibold leading-[1.35] text-fg transition-colors group-hover:text-brand">
+            {item.headline}
+          </h3>
+          <div className="flex items-center gap-1.5 font-mono text-[10px] text-fg-3 mt-1">
+            <span className="font-semibold text-fg-2">{item.source}</span>
+            <span>·</span>
+            <span>{relativeTime(item.publishedAt)}</span>
+          </div>
+        </article>
+      </Link>
+    );
+  }
+
+  if (variant === "compact") {
+    return (
+      <Link href={detailHref} className="card !p-4 block no-underline group">
+        <div className="flex items-center gap-2 mb-2">
+          {showCategory && <CategoryDot color={categoryColor} withLabel category={item.category} />}
+          {item.isBreaking && <BreakingBadge />}
+          {lowConfidence && <LowConfidenceBadge />}
+        </div>
+        <h3 className="font-display text-sm font-bold leading-[1.35] line-clamp-3 text-fg group-hover:text-brand transition-colors">
+          {item.headline}
+        </h3>
+        <div className="flex items-center gap-1.5 font-mono text-[10px] text-fg-3 mt-2">
+          <span className="font-semibold text-fg-2">{item.source}</span>
+          <span>·</span>
+          <span>{relativeTime(item.publishedAt)}</span>
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <article className="card relative group flex flex-col gap-3">
+      {/* Stretched link covers the card; sibling links remain clickable via z-index */}
+      <Link
+        href={detailHref}
+        aria-label={item.headline}
+        className="absolute inset-0 z-0 rounded-[var(--card-r)]"
+      />
+
+      <div className="relative z-10 flex items-center gap-2 flex-wrap pointer-events-none">
+        {showCategory && <CategoryDot color={categoryColor} withLabel category={item.category} />}
+        {item.isBreaking && <BreakingBadge />}
+        {lowConfidence && <LowConfidenceBadge />}
+        <span className="ml-auto font-mono text-[10px] text-fg-3">
+          {relativeTime(item.publishedAt)}
+        </span>
+      </div>
+
+      <h3 className="relative z-10 font-display text-base font-extrabold leading-[1.3] tracking-tight text-fg group-hover:text-brand transition-colors pointer-events-none">
+        {item.headline}
+      </h3>
+
+      {item.summary && (
+        <p className="relative z-10 text-sm text-fg-2 leading-[1.55] line-clamp-3 pointer-events-none">
+          {item.summary}
+        </p>
+      )}
+
+      <div className="relative z-10 flex items-center justify-between gap-3 mt-auto pt-2 border-t border-border-s pointer-events-none">
+        <div className="font-mono text-[11px] text-fg-2 font-semibold">
+          {item.source}
+        </div>
+        {showEntities && entityRefs.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap justify-end pointer-events-auto">
+            {entityRefs.slice(0, 3).map((e) => (
+              <Link
+                key={e.slug}
+                href={`/directory/${e.slug}`}
+                className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-brand-m text-brand no-underline hover:bg-brand hover:text-white transition-colors"
+              >
+                {e.ticker ?? e.name}
+              </Link>
+            ))}
+            {entityRefs.length > 3 && (
+              <span className="font-mono text-[10px] text-fg-3">
+                +{entityRefs.length - 3}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function CategoryDot({
+  color,
+  withLabel,
+  category,
+}: {
+  color: string;
+  withLabel?: boolean;
+  category?: keyof typeof NEWS_CATEGORY_LABELS;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span
+        className="w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ background: color }}
+      />
+      {withLabel && category && (
+        <span className="font-mono text-[10px] uppercase tracking-badge text-fg-2 font-semibold">
+          {NEWS_CATEGORY_LABELS[category]}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function BreakingBadge() {
+  return (
+    <span className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-badge font-bold text-[color:var(--neg-t)] bg-[var(--neg-m)] px-1.5 py-0.5 rounded-[var(--btn-r)]">
+      <span className="w-1 h-1 rounded-full bg-[color:var(--neg)] animate-pulse" />
+      Breaking
+    </span>
+  );
+}
+
+function LowConfidenceBadge() {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center font-mono text-[10px] uppercase tracking-badge font-semibold",
+        "text-fg-3 border border-border bg-[var(--surface-down)] px-1.5 py-0.5 rounded-[var(--btn-r)]"
+      )}
+      title="Low-confidence AI tagging — pending analyst review"
+    >
+      Unverified
+    </span>
+  );
+}
+
+export { relativeTime };

--- a/app/concierge/concierge-form.tsx
+++ b/app/concierge/concierge-form.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { cn } from "@/app/lib/cn";
+
+const REQUEST_TYPES = [
+  { value: "investor-intro", label: "Investor introduction" },
+  { value: "company-intro", label: "Company / management intro" },
+  { value: "deal-flow", label: "Deal flow access" },
+  { value: "research-request", label: "Custom research" },
+  { value: "general", label: "Something else" },
+] as const;
+
+const URGENCY = [
+  { value: "this-week", label: "This week" },
+  { value: "this-month", label: "Within a month" },
+  { value: "exploratory", label: "Exploratory" },
+] as const;
+
+const SECTORS = [
+  "Mining & Resources",
+  "Banking & Finance",
+  "Energy",
+  "Technology",
+  "Real Estate & Infrastructure",
+  "Capital Markets",
+  "Agriculture",
+  "Professional Services",
+];
+
+export function ConciergeForm() {
+  const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [requestType, setRequestType] = useState<string>("investor-intro");
+  const [urgency, setUrgency] = useState<string>("this-month");
+  const [sectorTags, setSectorTags] = useState<string[]>([]);
+
+  function handleSubmit(e: { preventDefault: () => void }) {
+    e.preventDefault();
+    setSubmitting(true);
+    setTimeout(() => {
+      setSubmitting(false);
+      setSubmitted(true);
+    }, 800);
+  }
+
+  function toggleSector(s: string) {
+    setSectorTags((prev) =>
+      prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]
+    );
+  }
+
+  if (submitted) {
+    return (
+      <div className="card !p-8 max-w-[520px] mx-auto text-center flex flex-col items-center gap-4">
+        <div className="w-12 h-12 rounded-full bg-pos-m grid place-items-center">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--pos-t)" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </div>
+        <div>
+          <div className="font-display font-extrabold text-md mb-2">
+            Request received.
+          </div>
+          <p className="text-sm text-fg-2 leading-[1.6] max-w-[400px]">
+            A CMM analyst will review your request and reach out within 1 business day. We&apos;ll match you with the right contact and confirm next steps over email.
+          </p>
+        </div>
+        <div className="flex gap-2 mt-2">
+          <Link href="/insights" className="btn btn-secondary text-sm">
+            Browse Insights
+          </Link>
+          <Link href="/account" className="btn btn-primary text-sm">
+            View My Requests
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="card !p-6 sm:!p-8 max-w-[640px] mx-auto flex flex-col gap-6"
+    >
+      <div>
+        <div className="font-display font-extrabold text-md mb-1">
+          Tell us what you need
+        </div>
+        <p className="text-sm text-fg-2 leading-[1.5]">
+          Describe your ask and CMM&apos;s analyst team will route it to the right person within 1 business day.
+        </p>
+      </div>
+
+      {/* Request type */}
+      <fieldset>
+        <legend className="block font-display font-semibold text-xs uppercase tracking-[0.08em] text-fg-3 mb-2">
+          What are you looking for?
+        </legend>
+        <div className="flex flex-wrap gap-2">
+          {REQUEST_TYPES.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setRequestType(opt.value)}
+              className={cn(
+                "px-3 py-1.5 rounded-[var(--btn-r)] text-sm font-medium border cursor-pointer transition-all",
+                requestType === opt.value
+                  ? "border-brand bg-brand-m text-brand font-semibold"
+                  : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l"
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      <Field
+        label="Brief summary"
+        name="summary"
+        textarea
+        required
+        placeholder="Eg. We're a Singapore-based credit fund looking to engage with mid-cap Mongolian banks on potential subordinated debt opportunities."
+      />
+
+      {/* Sectors */}
+      <fieldset>
+        <legend className="block font-display font-semibold text-xs uppercase tracking-[0.08em] text-fg-3 mb-2">
+          Sectors of interest
+        </legend>
+        <div className="flex flex-wrap gap-1.5">
+          {SECTORS.map((s) => {
+            const active = sectorTags.includes(s);
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => toggleSector(s)}
+                className={cn(
+                  "px-2.5 py-1 rounded-[var(--btn-r)] text-xs font-medium border cursor-pointer transition-all",
+                  active
+                    ? "border-brand bg-brand text-white"
+                    : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l"
+                )}
+              >
+                {s}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <Field
+        label="Specific entity, person, or deal (optional)"
+        name="targetEntity"
+        placeholder="Eg. Khan Bank, Tsakhia Solar Park, Erdenes Tavan Tolgoi IPO"
+      />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Field label="Your name" name="name" required />
+        <Field label="Work email" name="email" type="email" required />
+        <Field label="Company / Firm" name="company" required />
+        <Field label="Role" name="role" />
+      </div>
+
+      {/* Urgency */}
+      <fieldset>
+        <legend className="block font-display font-semibold text-xs uppercase tracking-[0.08em] text-fg-3 mb-2">
+          Timing
+        </legend>
+        <div className="flex gap-2">
+          {URGENCY.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setUrgency(opt.value)}
+              className={cn(
+                "flex-1 px-3 py-2 rounded-[var(--btn-r)] text-sm font-medium border cursor-pointer transition-all",
+                urgency === opt.value
+                  ? "border-brand bg-brand-m text-brand font-semibold"
+                  : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l"
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="btn btn-primary w-full justify-center"
+      >
+        {submitting ? "Sending…" : "Send request"}
+      </button>
+
+      <p className="text-[11px] text-fg-3 leading-[1.5] text-center">
+        CMM treats all concierge requests as confidential. By submitting you agree to our service terms.
+      </p>
+    </form>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  name: string;
+  type?: string;
+  required?: boolean;
+  textarea?: boolean;
+  placeholder?: string;
+}
+
+function Field({ label, name, type = "text", required, textarea, placeholder }: FieldProps) {
+  const baseCls =
+    "w-full px-3 py-2 bg-[var(--white)] border border-border rounded-[var(--btn-r)] text-sm text-fg placeholder:text-fg-3 focus:outline-none focus:border-brand-l transition-colors";
+
+  return (
+    <label className="block">
+      <span className="block font-display font-semibold text-xs uppercase tracking-[0.08em] text-fg-3 mb-1.5">
+        {label}
+        {required && <span className="text-brand ml-0.5">*</span>}
+      </span>
+      {textarea ? (
+        <textarea
+          name={name}
+          required={required}
+          placeholder={placeholder}
+          rows={4}
+          className={cn(baseCls, "resize-none leading-[1.5]")}
+        />
+      ) : (
+        <input
+          type={type}
+          name={name}
+          required={required}
+          placeholder={placeholder}
+          className={baseCls}
+        />
+      )}
+    </label>
+  );
+}

--- a/app/concierge/page.tsx
+++ b/app/concierge/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+import { ConciergeForm } from "./concierge-form";
+
+export const metadata: Metadata = {
+  title: "CMM Concierge — MarketIQ",
+  description:
+    "Request introductions to investors, companies, deal flow, or custom research. Routed to a CMM analyst within 1 business day.",
+};
+
+const VALUE_PROPS = [
+  {
+    label: "Direct access",
+    title: "Curated investor & operator intros",
+    body: "Hand-matched introductions to senior decision makers across mining, banking, and infrastructure.",
+  },
+  {
+    label: "Deal flow",
+    title: "Pre-marketing & private placements",
+    body: "First look at active mandates — bonds, equity raises, project finance — before they hit broader distribution.",
+  },
+  {
+    label: "Research",
+    title: "Bespoke market intelligence",
+    body: "Custom research, deep dives, and counterparty diligence delivered by CMM's analyst team.",
+  },
+];
+
+export default function ConciergePage() {
+  return (
+    <div className="content-max px-6 pb-16">
+      <div className="pt-10 pb-8 text-center">
+        <div className="font-mono text-[11px] uppercase tracking-badge text-brand mb-3">
+          CMM Concierge
+        </div>
+        <h1 className="font-display font-extrabold text-3xl tracking-tight leading-[1.05] max-md:text-2xl">
+          Get connected — fast.
+        </h1>
+        <p className="text-base text-fg-2 mt-3 max-w-[620px] mx-auto">
+          Tell us what you need and a CMM analyst will route your request within 1 business day. Used by 200+ investors and corporates this year.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-12 max-w-[920px] mx-auto">
+        {VALUE_PROPS.map((p) => (
+          <div
+            key={p.label}
+            className="card flex flex-col gap-2"
+          >
+            <div className="font-mono text-[10px] uppercase tracking-badge text-brand">
+              {p.label}
+            </div>
+            <div className="font-display font-extrabold text-sm leading-[1.3]">
+              {p.title}
+            </div>
+            <p className="text-xs text-fg-2 leading-[1.55]">
+              {p.body}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <ConciergeForm />
+    </div>
+  );
+}

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -1,0 +1,307 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { MOCK_EVENTS, MOCK_SPEAKERS, type MockEventAgendaItem } from "@/app/lib/mock-data";
+import { RegistrationForm } from "@/app/components/events/registration-form";
+import { SpeakerCard } from "@/app/components/events/speaker-card";
+import { formatDateRange, FORMAT_LABEL, STATUS_LABEL } from "@/app/components/events/event-card";
+import { cn } from "@/app/lib/cn";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const event = MOCK_EVENTS.find((e) => e.slug === slug);
+  if (!event) return { title: "Event Not Found — MarketIQ" };
+  return {
+    title: `${event.title} — MarketIQ`,
+    description: event.tagline,
+  };
+}
+
+export default async function EventDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+  const event = MOCK_EVENTS.find((e) => e.slug === slug);
+  if (!event) notFound();
+
+  const speakers = event.speakerSlugs
+    .map((s) => MOCK_SPEAKERS.find((sp) => sp.slug === s))
+    .filter((s): s is NonNullable<typeof s> => Boolean(s));
+
+  const status = STATUS_LABEL[event.status];
+  const isPast = event.status === "past";
+
+  return (
+    <div className="content-max px-6">
+      {/* Breadcrumb */}
+      <div className="pt-6 pb-3">
+        <Link
+          href="/events"
+          className="text-sm font-display font-semibold text-fg-3 hover:text-brand no-underline"
+        >
+          ← All events
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <header className="pb-8 border-b border-border-s">
+        <div className="flex items-center gap-2 flex-wrap mb-3">
+          <span
+            className={cn(
+              "inline-flex items-center font-mono uppercase font-semibold tracking-badge rounded-[var(--btn-r)] text-[10px] px-2 py-0.5",
+              status.tone === "signal" && "bg-[var(--signal-m)] text-[color:var(--signal-h)]",
+              status.tone === "pos" && "bg-[var(--pos-m)] text-[color:var(--pos-t)]",
+              status.tone === "neg" && "bg-[var(--neg-m)] text-[color:var(--neg-t)]",
+              status.tone === "fg" && "bg-surface text-fg-2"
+            )}
+          >
+            {status.label}
+          </span>
+          <span className="font-mono text-[11px] uppercase tracking-badge text-fg-3">
+            {FORMAT_LABEL[event.format]}
+          </span>
+          {event.topics?.map((t) => (
+            <span
+              key={t}
+              className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+
+        <h1 className="font-display font-extrabold text-3xl tracking-tight leading-[1.05] max-w-[800px] max-md:text-2xl">
+          {event.title}
+        </h1>
+        <p className="mt-3 text-base text-fg-2 max-w-[680px] leading-[1.55]">
+          {event.tagline}
+        </p>
+
+        <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4">
+          <Stat label="When" value={formatDateRange(event.startDate, event.endDate)} />
+          <Stat label="Where" value={event.location} />
+          {event.expectedAttendees && (
+            <Stat label="Attendees" value={`${event.expectedAttendees}+`} />
+          )}
+          {event.presentingCompanies && (
+            <Stat label="Presenting" value={`${event.presentingCompanies} companies`} />
+          )}
+        </div>
+      </header>
+
+      {/* Body */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-8 py-10">
+        <div className="min-w-0 flex flex-col gap-10">
+          {/* About */}
+          <section>
+            <SectionHeading>About this event</SectionHeading>
+            <p className="text-base text-fg-2 leading-[1.7] max-w-[680px]">
+              {event.description}
+            </p>
+          </section>
+
+          {/* Agenda */}
+          {event.agenda && event.agenda.length > 0 && (
+            <section>
+              <SectionHeading>Agenda</SectionHeading>
+              <ol className="flex flex-col">
+                {event.agenda.map((item, i) => (
+                  <AgendaRow key={i} item={item} speakerLookup={MOCK_SPEAKERS} />
+                ))}
+              </ol>
+            </section>
+          )}
+
+          {/* Speakers */}
+          {speakers.length > 0 && (
+            <section>
+              <SectionHeading>Speakers</SectionHeading>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {speakers.map((s) => (
+                  <SpeakerCard key={s.slug} speaker={s} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Sponsors */}
+          {event.sponsors && event.sponsors.length > 0 && (
+            <section>
+              <SectionHeading>Sponsors</SectionHeading>
+              {(["platinum", "gold", "silver", "partner"] as const).map((tier) => {
+                const tierSponsors = event.sponsors!.filter((s) => s.tier === tier);
+                if (tierSponsors.length === 0) return null;
+                return (
+                  <div key={tier} className="mb-5 last:mb-0">
+                    <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-2">
+                      {tier}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {tierSponsors.map((s) => (
+                        <span
+                          key={s.name}
+                          className="card !py-2 !px-3 text-sm font-display font-semibold"
+                        >
+                          {s.name}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </section>
+          )}
+
+          {/* Past event recap */}
+          {isPast && (event.recapUrl || event.replayUrl) && (
+            <section className="card !p-6">
+              <div className="font-display font-extrabold text-base mb-2">
+                Event recap
+              </div>
+              <p className="text-sm text-fg-2 mb-4 leading-[1.5]">
+                This event has concluded. Catch up on the highlights below.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {event.recapUrl && (
+                  <Link href={event.recapUrl} className="btn btn-primary text-sm">
+                    Read recap
+                  </Link>
+                )}
+                {event.replayUrl && (
+                  <Link href={event.replayUrl} className="btn btn-secondary text-sm">
+                    Watch replay
+                  </Link>
+                )}
+              </div>
+            </section>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <aside
+          className="flex flex-col gap-4 lg:sticky lg:self-start"
+          style={{ top: "calc(var(--header-h) + 24px)" }}
+        >
+          {!isPast && (
+            <RegistrationForm
+              eventTitle={event.shortName ?? event.title}
+              ticketPrice={event.ticketPrice}
+              registrationDeadline={event.registrationDeadline}
+            />
+          )}
+
+          {event.registrationCount && !isPast && (
+            <div className="card !p-4 flex items-center gap-3">
+              <div className="w-2 h-2 rounded-full bg-pos animate-pulse" />
+              <div className="text-xs text-fg-2">
+                <span className="font-display font-bold text-fg">
+                  {event.registrationCount}
+                </span>{" "}
+                registered so far
+              </div>
+            </div>
+          )}
+
+          {event.venue && (
+            <div className="card !p-4">
+              <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-2">
+                Venue
+              </div>
+              <div className="font-display font-bold text-sm mb-1">
+                {event.venue}
+              </div>
+              <div className="text-xs text-fg-2 leading-[1.5]">
+                {event.location}
+              </div>
+            </div>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="sticky z-20 -mx-2 px-2 py-2 backdrop-blur-md bg-[var(--header-blur)] border-b border-border-s mb-4"
+      style={{ top: "var(--header-h)" }}
+    >
+      <h2 className="font-display font-extrabold text-md tracking-tight">
+        {children}
+      </h2>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-1">
+        {label}
+      </div>
+      <div className="font-display font-bold text-sm leading-[1.3]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+const AGENDA_TYPE_TONE: Record<NonNullable<MockEventAgendaItem["type"]>, string> = {
+  keynote: "border-brand",
+  panel: "border-[color:var(--info)]",
+  presentation: "border-[color:var(--cat-sectors)]",
+  break: "border-border-s",
+  networking: "border-[color:var(--signal)]",
+};
+
+function AgendaRow({
+  item,
+  speakerLookup,
+}: {
+  item: MockEventAgendaItem;
+  speakerLookup: typeof MOCK_SPEAKERS;
+}) {
+  const tone = item.type ? AGENDA_TYPE_TONE[item.type] : "border-border-s";
+  const speakers = (item.speakerSlugs ?? [])
+    .map((s) => speakerLookup.find((sp) => sp.slug === s))
+    .filter((s): s is NonNullable<typeof s> => Boolean(s));
+
+  return (
+    <li className={cn("flex gap-4 py-3 pl-4 border-l-2 -ml-px", tone)}>
+      <div className="font-mono text-xs font-semibold text-fg-2 w-14 shrink-0 pt-0.5">
+        {item.time}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-display font-bold text-sm leading-[1.35]">
+          {item.title}
+        </div>
+        {item.description && (
+          <div className="text-xs text-fg-2 mt-1 leading-[1.5]">
+            {item.description}
+          </div>
+        )}
+        {speakers.length > 0 && (
+          <div className="flex flex-wrap gap-x-2 gap-y-1 mt-1.5">
+            {speakers.map((s) => (
+              <Link
+                key={s.slug}
+                href={`/events/speakers/${s.slug}`}
+                className="text-[11px] text-fg-3 hover:text-brand no-underline"
+              >
+                {s.name} <span className="text-fg-3">· {s.org}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+      {item.type && (
+        <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 shrink-0 pt-0.5">
+          {item.type}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MOCK_EVENTS } from "@/app/lib/mock-data";
+import { EventCard } from "@/app/components/events/event-card";
+
+export const metadata: Metadata = {
+  title: "Events — MarketIQ",
+  description:
+    "Conferences, investor days, and capital markets events curated by CMM.",
+};
+
+export default function EventsPage() {
+  const upcoming = MOCK_EVENTS.filter((e) => e.status !== "past").sort(
+    (a, b) => +new Date(a.startDate) - +new Date(b.startDate)
+  );
+  const past = MOCK_EVENTS.filter((e) => e.status === "past")
+    .sort((a, b) => +new Date(b.startDate) - +new Date(a.startDate))
+    .slice(0, 3);
+
+  const featured = upcoming[0];
+  const rest = upcoming.slice(1);
+
+  return (
+    <div className="content-max px-6">
+      <div className="pt-8 pb-6">
+        <div className="font-mono text-[11px] uppercase tracking-badge text-brand mb-2">
+          Events
+        </div>
+        <h1 className="font-display font-extrabold text-2xl tracking-tight leading-heading">
+          Capital markets events, in person and virtual
+        </h1>
+        <p className="text-base text-fg-2 mt-2 max-w-[560px]">
+          CMM-hosted forums, member briefings, and curated industry conferences. Register early — most fill up.
+        </p>
+      </div>
+
+      {/* Featured upcoming */}
+      {featured && (
+        <section className="mb-12">
+          <div
+            className="sticky z-20 -mx-2 px-2 py-2 backdrop-blur-md bg-[var(--header-blur)] border-b border-border-s flex items-baseline justify-between mb-4"
+            style={{ top: "var(--header-h)" }}
+          >
+            <h2 className="font-display font-extrabold text-md tracking-tight">
+              Next up
+            </h2>
+            <span className="font-mono text-[11px] text-fg-3 uppercase tracking-badge">
+              {upcoming.length} upcoming
+            </span>
+          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <div className="lg:col-span-2">
+              <EventCard event={featured} variant="featured" />
+            </div>
+            <div className="flex flex-col gap-3">
+              {rest.slice(0, 3).map((e) => (
+                <EventCard key={e.slug} event={e} variant="compact" />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* All upcoming grid */}
+      {rest.length > 0 && (
+        <section className="mb-12">
+          <div
+            className="sticky z-20 -mx-2 px-2 py-2 backdrop-blur-md bg-[var(--header-blur)] border-b border-border-s mb-4"
+            style={{ top: "var(--header-h)" }}
+          >
+            <h2 className="font-display font-extrabold text-md tracking-tight">
+              All upcoming
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {rest.map((e) => (
+              <EventCard key={e.slug} event={e} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Past events teaser */}
+      {past.length > 0 && (
+        <section className="mb-16">
+          <div
+            className="sticky z-20 -mx-2 px-2 py-2 backdrop-blur-md bg-[var(--header-blur)] border-b border-border-s flex items-baseline justify-between mb-4"
+            style={{ top: "var(--header-h)" }}
+          >
+            <h2 className="font-display font-extrabold text-md tracking-tight">
+              Recent past events
+            </h2>
+            <Link
+              href="/events/past"
+              className="text-sm font-display font-semibold text-brand hover:text-brand-h no-underline"
+            >
+              View archive →
+            </Link>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {past.map((e) => (
+              <EventCard key={e.slug} event={e} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/events/past/page.tsx
+++ b/app/events/past/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MOCK_EVENTS } from "@/app/lib/mock-data";
+import { EventCard } from "@/app/components/events/event-card";
+
+export const metadata: Metadata = {
+  title: "Past Events — MarketIQ",
+  description: "Archive of CMM-hosted forums, briefings, and conferences.",
+};
+
+export default function PastEventsPage() {
+  const past = MOCK_EVENTS.filter((e) => e.status === "past").sort(
+    (a, b) => +new Date(b.startDate) - +new Date(a.startDate)
+  );
+
+  const grouped = past.reduce<Record<string, typeof past>>((acc, e) => {
+    const year = new Date(e.startDate).getFullYear().toString();
+    (acc[year] ??= []).push(e);
+    return acc;
+  }, {});
+
+  const years = Object.keys(grouped).sort((a, b) => +b - +a);
+
+  return (
+    <div className="content-max px-6">
+      <div className="pt-6 pb-3">
+        <Link
+          href="/events"
+          className="text-sm font-display font-semibold text-fg-3 hover:text-brand no-underline"
+        >
+          ← All events
+        </Link>
+      </div>
+
+      <div className="pb-6">
+        <div className="font-mono text-[11px] uppercase tracking-badge text-fg-3 mb-2">
+          Archive
+        </div>
+        <h1 className="font-display font-extrabold text-2xl tracking-tight leading-heading">
+          Past events
+        </h1>
+        <p className="text-base text-fg-2 mt-2 max-w-[560px]">
+          Recaps, replays, and recordings from CMM-hosted forums and member briefings.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-12 pb-16">
+        {years.map((year) => (
+          <section key={year}>
+            <div
+              className="sticky z-20 -mx-2 px-2 py-2 backdrop-blur-md bg-[var(--header-blur)] border-b border-border-s flex items-baseline gap-3 mb-4"
+              style={{ top: "var(--header-h)" }}
+            >
+              <h2 className="font-display font-extrabold text-md tracking-tight">
+                {year}
+              </h2>
+              <span className="font-mono text-[11px] text-fg-3 uppercase tracking-badge">
+                {grouped[year].length} events
+              </span>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {grouped[year].map((e) => (
+                <EventCard key={e.slug} event={e} />
+              ))}
+            </div>
+          </section>
+        ))}
+
+        {past.length === 0 && (
+          <div className="py-20 text-center">
+            <p className="text-base text-fg-3">No past events yet.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/events/speakers/[slug]/page.tsx
+++ b/app/events/speakers/[slug]/page.tsx
@@ -1,0 +1,164 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { MOCK_EVENTS, MOCK_SPEAKERS } from "@/app/lib/mock-data";
+import { Avatar } from "@/app/components/events/speaker-card";
+import { EventCard } from "@/app/components/events/event-card";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const speaker = MOCK_SPEAKERS.find((s) => s.slug === slug);
+  if (!speaker) return { title: "Speaker — MarketIQ" };
+  return {
+    title: `${speaker.name} — MarketIQ`,
+    description: `${speaker.title}, ${speaker.org}`,
+  };
+}
+
+export default async function SpeakerProfilePage({ params }: PageProps) {
+  const { slug } = await params;
+  const speaker = MOCK_SPEAKERS.find((s) => s.slug === slug);
+  if (!speaker) notFound();
+
+  const eventsBySpeaker = MOCK_EVENTS.filter((e) =>
+    e.speakerSlugs.includes(speaker.slug)
+  ).sort((a, b) => +new Date(b.startDate) - +new Date(a.startDate));
+
+  const upcomingEvents = eventsBySpeaker.filter((e) => e.status !== "past");
+  const pastEvents = eventsBySpeaker.filter((e) => e.status === "past");
+
+  return (
+    <div className="content-max px-6">
+      <div className="pt-6 pb-3">
+        <Link
+          href="/events"
+          className="text-sm font-display font-semibold text-fg-3 hover:text-brand no-underline"
+        >
+          ← Events
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <header className="py-8 border-b border-border-s flex items-start gap-6 max-md:flex-col">
+        <Avatar speaker={speaker} size="lg" />
+        <div className="flex-1 min-w-0">
+          <h1 className="font-display font-extrabold text-2xl tracking-tight leading-heading">
+            {speaker.name}
+          </h1>
+          <div className="text-base text-fg-2 mt-1">
+            {speaker.title}
+          </div>
+          <div className="text-sm text-fg-3 mt-0.5">
+            {speaker.orgSlug ? (
+              <Link
+                href={`/directory/${speaker.orgSlug}`}
+                className="text-brand hover:text-brand-h no-underline"
+              >
+                {speaker.org}
+              </Link>
+            ) : (
+              speaker.org
+            )}
+          </div>
+
+          {speaker.expertise && speaker.expertise.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-4">
+              {speaker.expertise.map((tag) => (
+                <span
+                  key={tag}
+                  className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-8 py-10">
+        <div className="min-w-0 flex flex-col gap-10">
+          {/* Bio */}
+          <section>
+            <h2 className="font-display font-extrabold text-md tracking-tight mb-3">
+              About
+            </h2>
+            <p className="text-base text-fg-2 leading-[1.7] max-w-[680px]">
+              {speaker.bio}
+            </p>
+          </section>
+
+          {/* Upcoming sessions */}
+          {upcomingEvents.length > 0 && (
+            <section>
+              <h2 className="font-display font-extrabold text-md tracking-tight mb-4">
+                Upcoming sessions
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {upcomingEvents.map((e) => (
+                  <EventCard key={e.slug} event={e} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Past appearances */}
+          {pastEvents.length > 0 && (
+            <section>
+              <h2 className="font-display font-extrabold text-md tracking-tight mb-4">
+                Past appearances
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {pastEvents.map((e) => (
+                  <EventCard key={e.slug} event={e} />
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+
+        <aside
+          className="flex flex-col gap-4 lg:sticky lg:self-start"
+          style={{ top: "calc(var(--header-h) + 24px)" }}
+        >
+          <div className="card !p-4">
+            <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-3">
+              Connect
+            </div>
+            {(speaker.linkedinUrl || speaker.twitterUrl || speaker.websiteUrl) ? (
+              <div className="flex flex-col gap-2">
+                {speaker.linkedinUrl && (
+                  <Link href={speaker.linkedinUrl} className="text-sm font-medium text-brand hover:text-brand-h no-underline">
+                    LinkedIn →
+                  </Link>
+                )}
+                {speaker.twitterUrl && (
+                  <Link href={speaker.twitterUrl} className="text-sm font-medium text-brand hover:text-brand-h no-underline">
+                    Twitter →
+                  </Link>
+                )}
+                {speaker.websiteUrl && (
+                  <Link href={speaker.websiteUrl} className="text-sm font-medium text-brand hover:text-brand-h no-underline">
+                    Website →
+                  </Link>
+                )}
+              </div>
+            ) : (
+              <p className="text-xs text-fg-3 leading-[1.5]">
+                Reach out via{" "}
+                <Link href="/concierge" className="text-brand hover:text-brand-h no-underline">
+                  CMM Concierge
+                </Link>{" "}
+                to connect with {speaker.name.split(" ")[0]}.
+              </p>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/app/feed/[id]/page.tsx
+++ b/app/feed/[id]/page.tsx
@@ -1,0 +1,213 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  MOCK_NEWS,
+  MOCK_ENTITIES,
+  NEWS_CATEGORY_COLORS,
+  NEWS_CATEGORY_LABELS,
+} from "@/app/lib/mock-data";
+import { NewsItemCard } from "@/app/components/feed/news-item-card";
+import { cn } from "@/app/lib/cn";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const item = MOCK_NEWS.find((n) => n.id === id);
+  if (!item) return { title: "News Not Found — MarketIQ" };
+  return {
+    title: `${item.headline} — MarketIQ`,
+    description: item.summary,
+  };
+}
+
+export default async function NewsDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const item = MOCK_NEWS.find((n) => n.id === id);
+  if (!item) notFound();
+
+  const entities = item.entitySlugs
+    .map((slug) => MOCK_ENTITIES.find((e) => e.slug === slug))
+    .filter((e): e is NonNullable<typeof e> => Boolean(e));
+
+  const related = MOCK_NEWS.filter(
+    (n) =>
+      n.id !== item.id &&
+      (n.category === item.category ||
+        n.entitySlugs.some((s) => item.entitySlugs.includes(s)))
+  )
+    .sort((a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt))
+    .slice(0, 4);
+
+  const lowConfidence = item.confidence < 0.75;
+  const categoryColor = NEWS_CATEGORY_COLORS[item.category];
+  const categoryLabel = NEWS_CATEGORY_LABELS[item.category];
+
+  const publishedDate = new Date(item.publishedAt).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  return (
+    <div className="content-max px-6">
+      <div className="pt-6 pb-3">
+        <Link
+          href="/feed"
+          className="text-sm font-display font-semibold text-fg-3 hover:text-brand no-underline"
+        >
+          ← Market Feed
+        </Link>
+      </div>
+
+      <article className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-8 pb-12">
+        <div className="min-w-0">
+          <header className="pb-6 border-b border-border-s">
+            <div className="flex items-center gap-2 flex-wrap mb-3">
+              <span
+                className="inline-flex items-center gap-1.5 font-mono uppercase font-semibold tracking-badge rounded-[var(--btn-r)] text-[10px] px-2 py-0.5 text-fg-2"
+                style={{ background: "var(--surface)" }}
+              >
+                <span
+                  className="w-1.5 h-1.5 rounded-full"
+                  style={{ background: categoryColor }}
+                />
+                {categoryLabel}
+              </span>
+              {item.isBreaking && (
+                <span className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-badge font-bold text-[color:var(--neg-t)] bg-[var(--neg-m)] px-1.5 py-0.5 rounded-[var(--btn-r)]">
+                  <span className="w-1 h-1 rounded-full bg-[color:var(--neg)] animate-pulse" />
+                  Breaking
+                </span>
+              )}
+              {lowConfidence && (
+                <span
+                  className={cn(
+                    "inline-flex items-center font-mono text-[10px] uppercase tracking-badge font-semibold",
+                    "text-fg-3 border border-border bg-[var(--surface-down)] px-1.5 py-0.5 rounded-[var(--btn-r)]"
+                  )}
+                  title="Low-confidence AI tagging — pending analyst review"
+                >
+                  Unverified
+                </span>
+              )}
+            </div>
+
+            <h1 className="font-display font-extrabold text-2xl leading-[1.15] tracking-tight max-md:text-xl">
+              {item.headline}
+            </h1>
+
+            <div className="flex items-center gap-2 mt-4 font-mono text-[11px] text-fg-3">
+              <span className="font-semibold text-fg-2">{item.source}</span>
+              <span>·</span>
+              <span>{publishedDate}</span>
+            </div>
+          </header>
+
+          {item.summary && (
+            <section className="py-6">
+              <p className="text-base text-fg-2 leading-[1.7] max-w-[680px]">
+                {item.summary}
+              </p>
+              <p className="text-sm text-fg-3 leading-[1.6] mt-4 max-w-[680px]">
+                Full coverage and analyst commentary will appear here once linked from {item.source}.
+                {item.sourceUrl && (
+                  <>
+                    {" "}
+                    <Link
+                      href={item.sourceUrl}
+                      className="text-brand hover:text-brand-h no-underline"
+                    >
+                      Read original →
+                    </Link>
+                  </>
+                )}
+              </p>
+            </section>
+          )}
+
+          {related.length > 0 && (
+            <section className="pt-6 mt-6 border-t border-border-s">
+              <h2 className="font-display font-extrabold text-md tracking-tight mb-4">
+                Related coverage
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {related.map((r) => (
+                  <NewsItemCard key={r.id} item={r} />
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <aside
+          className="flex flex-col gap-4 lg:sticky lg:self-start"
+          style={{ top: "calc(var(--header-h) + 24px)" }}
+        >
+          <div className="card !p-4">
+            <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-3">
+              Confidence
+            </div>
+            <div className="flex items-baseline gap-2">
+              <div className="font-display font-extrabold text-2xl">
+                {Math.round(item.confidence * 100)}%
+              </div>
+              <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3">
+                {item.reviewed ? "Analyst-reviewed" : lowConfidence ? "Pending review" : "Auto-tagged"}
+              </div>
+            </div>
+          </div>
+
+          {entities.length > 0 && (
+            <div className="card !p-4">
+              <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-3">
+                Linked entities
+              </div>
+              <div className="flex flex-col gap-1">
+                {entities.map((e) => (
+                  <Link
+                    key={e.slug}
+                    href={`/directory/${e.slug}`}
+                    className="text-sm font-display font-semibold text-fg hover:text-brand no-underline py-1"
+                  >
+                    {e.name}
+                    {e.ticker && (
+                      <span className="font-mono text-[11px] text-fg-3 ml-2">
+                        {e.ticker}
+                      </span>
+                    )}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {item.topics && item.topics.length > 0 && (
+            <div className="card !p-4">
+              <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-3">
+                Topics
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {item.topics.map((t) => (
+                  <span
+                    key={t}
+                    className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </aside>
+      </article>
+    </div>
+  );
+}

--- a/app/feed/feed-stream.tsx
+++ b/app/feed/feed-stream.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  type MockNewsItem,
+  type NewsCategory,
+  NEWS_CATEGORY_LABELS,
+} from "@/app/lib/mock-data";
+import { NewsItemCard } from "@/app/components/feed/news-item-card";
+import { cn } from "@/app/lib/cn";
+
+const CATEGORIES: { value: NewsCategory | "all"; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "markets", label: NEWS_CATEGORY_LABELS.markets },
+  { value: "companies", label: NEWS_CATEGORY_LABELS.companies },
+  { value: "sectors", label: NEWS_CATEGORY_LABELS.sectors },
+  { value: "policy", label: NEWS_CATEGORY_LABELS.policy },
+  { value: "deals", label: NEWS_CATEGORY_LABELS.deals },
+  { value: "macro", label: NEWS_CATEGORY_LABELS.macro },
+];
+
+type SourceFilter = "all" | "verified" | "unverified";
+
+interface FeedStreamProps {
+  items: MockNewsItem[];
+}
+
+export function FeedStream({ items }: FeedStreamProps) {
+  const [category, setCategory] = useState<NewsCategory | "all">("all");
+  const [source, setSource] = useState<SourceFilter>("all");
+  const [activeSource, setActiveSource] = useState<string | null>(null);
+
+  const sources = useMemo(() => {
+    const set = new Set<string>();
+    items.forEach((i) => set.add(i.source));
+    return Array.from(set).sort();
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    let result = items;
+    if (category !== "all") result = result.filter((i) => i.category === category);
+    if (source === "verified") result = result.filter((i) => i.confidence >= 0.75);
+    if (source === "unverified") result = result.filter((i) => i.confidence < 0.75);
+    if (activeSource) result = result.filter((i) => i.source === activeSource);
+    return result;
+  }, [items, category, source, activeSource]);
+
+  const grouped = useMemo(() => groupByDay(filtered), [filtered]);
+
+  const activeCategoryLabel =
+    category === "all" ? null : NEWS_CATEGORY_LABELS[category];
+
+  return (
+    <>
+      {/* Page title — dynamic */}
+      <div className="pt-8 pb-6">
+        <div className="flex items-center gap-3">
+          <h1 className="font-display font-extrabold text-2xl tracking-tight leading-heading">
+            {activeCategoryLabel ?? "Market Feed"}
+          </h1>
+          {activeCategoryLabel && (
+            <button
+              onClick={() => setCategory("all")}
+              className="font-display font-semibold text-sm text-fg-3 hover:text-brand cursor-pointer bg-transparent border-none leading-none mt-px"
+            >
+              ← All
+            </button>
+          )}
+        </div>
+        <p className="text-base text-fg-2 mt-1">
+          Headlines from local and global wires, AI-tagged to entities and reviewed by CMM analysts.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_260px] gap-8">
+        <div className="min-w-0">
+          {/* Category tabs */}
+          <div className="flex items-center gap-1 mb-4 overflow-x-auto scrollbar-none -mx-1 px-1">
+            {CATEGORIES.map((c) => (
+              <button
+                key={c.value}
+                onClick={() => setCategory(c.value)}
+                className={cn(
+                  "px-3 py-1.5 rounded-[var(--btn-r)] text-sm font-display font-semibold whitespace-nowrap transition-all border cursor-pointer",
+                  category === c.value
+                    ? "border-brand bg-brand-m text-brand"
+                    : "border-transparent text-fg-2 hover:text-fg hover:bg-surface"
+                )}
+              >
+                {c.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Result meta */}
+          <div className="flex items-center justify-between mb-4">
+            <span className="font-mono text-[11px] text-fg-3 uppercase tracking-badge">
+              {filtered.length} item{filtered.length === 1 ? "" : "s"}
+            </span>
+            <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-badge text-fg-3">
+              <span className="flex items-center gap-1.5">
+                <span className="w-1.5 h-1.5 rounded-full bg-pos animate-pulse" />
+                Live
+              </span>
+            </div>
+          </div>
+
+          {/* Grouped feed */}
+          {grouped.length === 0 ? (
+            <div className="py-20 text-center">
+              <p className="text-base text-fg-3">No items match these filters.</p>
+              <button
+                onClick={() => {
+                  setCategory("all");
+                  setSource("all");
+                  setActiveSource(null);
+                }}
+                className="btn btn-secondary text-sm mt-4"
+              >
+                Reset filters
+              </button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-8">
+              {grouped.map(([label, group]) => (
+                <section key={label}>
+                  <div
+                    className="sticky z-20 -mx-2 px-2 py-2 backdrop-blur-md bg-[var(--header-blur)] border-b border-border-s flex items-center gap-3 mb-3"
+                    style={{ top: "var(--header-h)" }}
+                  >
+                    <h2 className="font-display font-extrabold text-sm uppercase tracking-[0.08em] text-fg-2">
+                      {label}
+                    </h2>
+                    <div className="flex-1 h-px bg-border-s" />
+                    <span className="font-mono text-[10px] text-fg-3 uppercase tracking-badge">
+                      {group.length}
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    {group.map((item) => (
+                      <NewsItemCard key={item.id} item={item} />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <aside
+          className="flex flex-col gap-4 lg:sticky lg:self-start"
+          style={{ top: "calc(var(--header-h) + 24px)" }}
+        >
+          <div className="card !p-4">
+            <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-3">
+              Confidence
+            </div>
+            <div className="flex flex-col gap-1">
+              {(["all", "verified", "unverified"] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setSource(s)}
+                  className={cn(
+                    "text-left px-2 py-1.5 rounded-[var(--btn-r)] text-sm font-medium cursor-pointer transition-colors border-none",
+                    source === s
+                      ? "bg-brand-m text-brand font-semibold"
+                      : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg"
+                  )}
+                >
+                  {s === "all" ? "All items" : s === "verified" ? "Analyst-reviewed" : "Pending review"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="card !p-4">
+            <div className="font-mono text-[10px] uppercase tracking-badge text-fg-3 mb-3">
+              Sources
+            </div>
+            <div className="flex flex-col gap-1 max-h-[240px] overflow-y-auto scrollbar-none">
+              <button
+                onClick={() => setActiveSource(null)}
+                className={cn(
+                  "text-left px-2 py-1.5 rounded-[var(--btn-r)] text-sm font-medium cursor-pointer transition-colors border-none",
+                  activeSource === null
+                    ? "bg-brand-m text-brand font-semibold"
+                    : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg"
+                )}
+              >
+                All sources
+              </button>
+              {sources.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setActiveSource(activeSource === s ? null : s)}
+                  className={cn(
+                    "text-left px-2 py-1.5 rounded-[var(--btn-r)] text-sm font-medium cursor-pointer transition-colors border-none",
+                    activeSource === s
+                      ? "bg-brand-m text-brand font-semibold"
+                      : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg"
+                  )}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        </aside>
+      </div>
+    </>
+  );
+}
+
+function groupByDay(items: MockNewsItem[]): [string, MockNewsItem[]][] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayMs = today.getTime();
+  const yesterdayMs = todayMs - 24 * 60 * 60 * 1000;
+  const weekAgoMs = todayMs - 7 * 24 * 60 * 60 * 1000;
+
+  const buckets: Record<string, MockNewsItem[]> = {
+    Today: [],
+    Yesterday: [],
+    "This week": [],
+    Earlier: [],
+  };
+
+  items
+    .slice()
+    .sort((a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt))
+    .forEach((item) => {
+      const t = new Date(item.publishedAt).getTime();
+      if (t >= todayMs) buckets.Today.push(item);
+      else if (t >= yesterdayMs) buckets.Yesterday.push(item);
+      else if (t >= weekAgoMs) buckets["This week"].push(item);
+      else buckets.Earlier.push(item);
+    });
+
+  return Object.entries(buckets).filter(([, v]) => v.length > 0);
+}

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { MOCK_NEWS } from "@/app/lib/mock-data";
+import { FeedStream } from "./feed-stream";
+
+export const metadata: Metadata = {
+  title: "Market Feed — MarketIQ",
+  description:
+    "Live news feed from Mongolia's capital markets, AI-aggregated and analyst-reviewed.",
+};
+
+export default function FeedPage() {
+  return (
+    <div className="content-max px-6">
+      <FeedStream items={MOCK_NEWS} />
+    </div>
+  );
+}

--- a/app/insights/insights-controls.tsx
+++ b/app/insights/insights-controls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect, useCallback } from "react";
-import { InsightsGrid, type GridLayout } from "@/app/components/insights/insights-grid";
+import { InsightsGrid } from "@/app/components/insights/insights-grid";
 import type { Article } from "@/app/components/insights/insights-grid";
 import { PaywallCounter } from "@/app/components/ui/paywall-counter";
 import { cn } from "@/app/lib/cn";
@@ -31,14 +31,6 @@ const TOPICS = [
   "Trade & Geopolitics",
 ];
 
-const LAYOUT_VARIANTS: { id: string; label: string; layout: GridLayout; showTags: boolean }[] = [
-  { id: "v1", label: "V1 · No hero · Tags", layout: "no-hero", showTags: true },
-  { id: "v2", label: "V2 · No hero · No tags", layout: "no-hero", showTags: false },
-  { id: "v3", label: "V3 · Semafor · Tags", layout: "semafor", showTags: true },
-  { id: "v4", label: "V4 · Semafor · No tags", layout: "semafor", showTags: false },
-];
-
-
 interface InsightsControlsProps {
   articles: Article[];
 }
@@ -47,10 +39,6 @@ export function InsightsControls({ articles }: InsightsControlsProps) {
   const [filter, setFilter] = useState("all");
   const [topic, setTopic] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [variantId, setVariantId] = useState<string>("v1");
-  const [switcherOpen, setSwitcherOpen] = useState(true);
-
-  const variant = LAYOUT_VARIANTS.find((v) => v.id === variantId) ?? LAYOUT_VARIANTS[0];
 
   const filtered = useMemo(() => {
     let result = articles;
@@ -231,8 +219,8 @@ export function InsightsControls({ articles }: InsightsControlsProps) {
           articles={filtered}
           onBadgeClick={handleBadgeClick}
           activeFilter={filter}
-          layout={variant.layout}
-          showTags={variant.showTags}
+          layout="no-hero"
+          showTags
         />
       ) : (
         <div className="py-20 text-center">
@@ -252,51 +240,6 @@ export function InsightsControls({ articles }: InsightsControlsProps) {
           </button>
         </div>
       )}
-
-      {/* ── Floating layout switcher ── */}
-      <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-[70] flex flex-col items-center gap-2">
-        {switcherOpen ? (
-          <div className="bg-[var(--white)] border border-border rounded-[var(--card-r)] shadow-xl p-2 min-w-[220px]">
-            <div className="flex items-center justify-between px-2 py-1.5 mb-1">
-              <span className="font-display font-bold text-[11px] uppercase tracking-[0.08em] text-fg-3">
-                Layout preview
-              </span>
-              <button
-                onClick={() => setSwitcherOpen(false)}
-                aria-label="Close switcher"
-                className="w-5 h-5 rounded grid place-items-center cursor-pointer border-none bg-transparent text-fg-3 hover:text-fg"
-              >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round">
-                  <path d="M18 6 6 18M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="flex flex-col gap-0.5">
-              {LAYOUT_VARIANTS.map((v) => (
-                <button
-                  key={v.id}
-                  onClick={() => setVariantId(v.id)}
-                  className={cn(
-                    "text-left px-3 py-2 rounded-[var(--btn-r)] text-xs font-medium cursor-pointer transition-all duration-[200ms] border-none",
-                    v.id === variantId
-                      ? "bg-brand-m text-brand font-semibold"
-                      : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg"
-                  )}
-                >
-                  {v.label}
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <button
-            onClick={() => setSwitcherOpen(true)}
-            className="bg-[var(--white)] border border-border rounded-full shadow-xl px-4 py-2 text-xs font-display font-bold text-fg cursor-pointer hover:border-brand-l transition-colors"
-          >
-            Layout · {variant.id.toUpperCase()}
-          </button>
-        )}
-      </div>
     </>
   );
 }

--- a/app/lib/mock-data.ts
+++ b/app/lib/mock-data.ts
@@ -911,3 +911,561 @@ export const SERIES = [
   "DealBook",
   "Investor Guide to Mongolia",
 ] as const;
+
+/* ── Events ────────────────────────────── */
+
+export type EventStatus = "upcoming" | "past" | "registration-open" | "sold-out";
+export type EventFormat = "in-person" | "virtual" | "hybrid";
+
+export interface MockEventAgendaItem {
+  time: string;
+  title: string;
+  speakerSlugs?: string[];
+  description?: string;
+  type?: "keynote" | "panel" | "presentation" | "break" | "networking";
+}
+
+export interface MockEventSponsor {
+  name: string;
+  tier: "platinum" | "gold" | "silver" | "partner";
+  logo?: string;
+}
+
+export interface MockEvent {
+  slug: string;
+  title: string;
+  shortName?: string;
+  tagline: string;
+  description: string;
+  status: EventStatus;
+  format: EventFormat;
+  startDate: string;
+  endDate?: string;
+  location: string;
+  venue?: string;
+  city?: string;
+  expectedAttendees?: number;
+  presentingCompanies?: number;
+  registrationCount?: number;
+  registrationDeadline?: string;
+  ticketPrice?: string;
+  coverImage?: string;
+  speakerSlugs: string[];
+  sponsors?: MockEventSponsor[];
+  agenda?: MockEventAgendaItem[];
+  recapUrl?: string;
+  replayUrl?: string;
+  topics?: string[];
+}
+
+export const MOCK_EVENTS: MockEvent[] = [
+  {
+    slug: "mif-2026",
+    title: "Mongolia Investment Forum 2026",
+    shortName: "MIF 2026",
+    tagline: "The annual gathering of Mongolia's capital markets",
+    description:
+      "MIF 2026 is the year's flagship gathering for institutional investors, sovereign funds, and Mongolia's leading corporates. Two days of keynotes, deal-flow presentations, and curated 1:1 meetings centered on the country's mining, banking, and energy growth stories.",
+    status: "registration-open",
+    format: "in-person",
+    startDate: "2026-05-15",
+    endDate: "2026-05-16",
+    location: "Shangri-La Hotel, Ulaanbaatar",
+    venue: "Shangri-La Ballroom",
+    city: "Ulaanbaatar",
+    expectedAttendees: 200,
+    presentingCompanies: 40,
+    registrationCount: 142,
+    registrationDeadline: "2026-05-10",
+    ticketPrice: "MNT 1,200,000",
+    coverImage: "/events/mif-2026.webp",
+    speakerSlugs: ["uchral-n", "byambasaikhan-b", "khan-bank-ceo", "rio-tinto-cfo", "namkhaidorj-b-speaker"],
+    sponsors: [
+      { name: "Khan Bank", tier: "platinum" },
+      { name: "Trade and Development Bank", tier: "platinum" },
+      { name: "Rio Tinto", tier: "gold" },
+      { name: "KPMG Mongolia", tier: "gold" },
+      { name: "Baker McKenzie", tier: "silver" },
+      { name: "Golomt Bank", tier: "silver" },
+    ],
+    agenda: [
+      { time: "08:30", title: "Registration & Coffee", type: "break" },
+      { time: "09:00", title: "Opening Keynote: Mongolia's 2026 Outlook", speakerSlugs: ["uchral-n"], type: "keynote" },
+      { time: "10:00", title: "Banking Sector Panel: Capital Formation in 2026", speakerSlugs: ["khan-bank-ceo", "namkhaidorj-b-speaker"], type: "panel" },
+      { time: "11:15", title: "Coffee Break", type: "break" },
+      { time: "11:30", title: "Mining: Oyu Tolgoi Phase 2 & Beyond", speakerSlugs: ["rio-tinto-cfo"], type: "presentation" },
+      { time: "12:30", title: "Lunch & Networking", type: "networking" },
+      { time: "14:00", title: "Capital Markets Reform: Where We Are", speakerSlugs: ["byambasaikhan-b"], type: "panel" },
+      { time: "15:30", title: "Investor 1:1 Sessions", type: "networking" },
+      { time: "18:00", title: "Welcome Reception", type: "networking" },
+    ],
+    topics: ["Capital Markets", "Mining & Resources", "Banking & Finance"],
+  },
+  {
+    slug: "mongolia-mining-summit-2026",
+    title: "Mongolia Mining & Energy Summit",
+    shortName: "MMES 2026",
+    tagline: "Critical minerals, copper, and the energy transition",
+    description:
+      "A focused one-day summit on Mongolia's role in the global critical minerals supply chain. Operator presentations, off-take negotiations, and policy briefings from the Ministry of Mining.",
+    status: "registration-open",
+    format: "hybrid",
+    startDate: "2026-06-12",
+    location: "Blue Sky Tower, Ulaanbaatar",
+    venue: "Blue Sky Conference Hall",
+    city: "Ulaanbaatar",
+    expectedAttendees: 120,
+    presentingCompanies: 18,
+    registrationCount: 64,
+    ticketPrice: "MNT 800,000",
+    coverImage: "/events/mining-summit-2026.webp",
+    speakerSlugs: ["damdinnyam-g", "rio-tinto-cfo", "ariunzaya-o-speaker"],
+    sponsors: [
+      { name: "Rio Tinto", tier: "platinum" },
+      { name: "Erdenes Mongol", tier: "gold" },
+    ],
+    topics: ["Mining & Resources", "Energy", "Policy & Regulation"],
+  },
+  {
+    slug: "cmm-investor-day-spring-2026",
+    title: "CMM Investor Day — Spring 2026",
+    tagline: "Quarterly briefing for CMM members",
+    description:
+      "A members-only briefing covering the Q1 2026 macro picture, banking sector earnings recap, and CMM's deal pipeline outlook.",
+    status: "registration-open",
+    format: "virtual",
+    startDate: "2026-05-28",
+    location: "Online (Zoom)",
+    expectedAttendees: 80,
+    registrationCount: 41,
+    ticketPrice: "Members only",
+    coverImage: "/events/investor-day-spring.webp",
+    speakerSlugs: ["namkhaidorj-b-speaker", "ariunzaya-o-speaker"],
+    topics: ["Capital Markets", "Banking & Finance"],
+  },
+  {
+    slug: "cmm-investor-day-winter-2025",
+    title: "CMM Investor Day — Winter 2025",
+    tagline: "2026 outlook & 2025 deal recap",
+    description:
+      "Members briefing covering 2025 deal recap, 2026 themes, and the inaugural Mongolia DealBook 2025 launch.",
+    status: "past",
+    format: "hybrid",
+    startDate: "2025-12-04",
+    location: "Shangri-La Hotel, Ulaanbaatar",
+    city: "Ulaanbaatar",
+    expectedAttendees: 90,
+    registrationCount: 88,
+    coverImage: "/events/investor-day-winter.webp",
+    speakerSlugs: ["namkhaidorj-b-speaker", "byambasaikhan-b"],
+    recapUrl: "/insights/mongolia-dealbook-2025",
+    replayUrl: "#",
+    topics: ["Capital Markets"],
+  },
+  {
+    slug: "mif-2025",
+    title: "Mongolia Investment Forum 2025",
+    shortName: "MIF 2025",
+    tagline: "Last year's flagship — 180 attendees",
+    description:
+      "MIF 2025 brought together 180+ institutional investors and 35 presenting companies. Highlights included the launch of Mongolia DealBook and the Bank of Mongolia governor's keynote.",
+    status: "past",
+    format: "in-person",
+    startDate: "2025-05-22",
+    endDate: "2025-05-23",
+    location: "Shangri-La Hotel, Ulaanbaatar",
+    city: "Ulaanbaatar",
+    expectedAttendees: 180,
+    presentingCompanies: 35,
+    registrationCount: 184,
+    coverImage: "/events/mif-2025.webp",
+    speakerSlugs: ["khan-bank-ceo", "byambasaikhan-b"],
+    recapUrl: "#",
+    replayUrl: "#",
+    topics: ["Capital Markets", "Banking & Finance"],
+  },
+  {
+    slug: "esg-mongolia-2025",
+    title: "ESG Mongolia 2025",
+    tagline: "Sustainable finance & climate disclosure",
+    description:
+      "Half-day workshop on Mongolia's SDG Finance Taxonomy adoption, IFC Performance Standards, and bank-led green finance initiatives.",
+    status: "past",
+    format: "in-person",
+    startDate: "2025-10-15",
+    location: "Corporate Hotel, Ulaanbaatar",
+    city: "Ulaanbaatar",
+    expectedAttendees: 70,
+    registrationCount: 72,
+    coverImage: "/events/esg-mongolia-2025.webp",
+    speakerSlugs: ["ariunzaya-o-speaker"],
+    recapUrl: "#",
+    topics: ["ESG & Climate", "Banking & Finance"],
+  },
+];
+
+/* ── Speakers ──────────────────────────── */
+
+export interface MockSpeaker {
+  slug: string;
+  name: string;
+  initials: string;
+  title: string;
+  org: string;
+  orgSlug?: string;
+  bio: string;
+  expertise?: string[];
+  photo?: string;
+  linkedinUrl?: string;
+  twitterUrl?: string;
+  websiteUrl?: string;
+}
+
+export const MOCK_SPEAKERS: MockSpeaker[] = [
+  {
+    slug: "uchral-n",
+    name: "Uchral N.",
+    initials: "UN",
+    title: "Prime Minister",
+    org: "Government of Mongolia",
+    bio: "Prime Minister of Mongolia since April 2026. Previously Minister of Digital Development and Communications, where he championed capital markets reform and delivered the Orano uranium agreement.",
+    expertise: ["Policy & Regulation", "Capital Markets", "Foreign Investment"],
+  },
+  {
+    slug: "byambasaikhan-b",
+    name: "Byambasaikhan B.",
+    initials: "BB",
+    title: "Board Chair",
+    org: "Tavan Tolgoi JSC",
+    orgSlug: "tavan-tolgoi",
+    bio: "Veteran capital markets executive. Board Chair at Tavan Tolgoi JSC and former CEO of Erdenes Mongol. Frequent contributor to CMM research on state-owned enterprises and IPO readiness.",
+    expertise: ["Capital Markets", "State-Owned Enterprises", "Mining & Resources"],
+  },
+  {
+    slug: "khan-bank-ceo",
+    name: "John Bell",
+    initials: "JB",
+    title: "Chief Executive Officer",
+    org: "Khan Bank",
+    orgSlug: "khan-bank",
+    bio: "CEO of Khan Bank since 2023. Previously held senior roles at HSBC and Standard Chartered across Asia. Leading Khan Bank's digital banking transformation.",
+    expertise: ["Banking & Finance", "Digital Transformation"],
+  },
+  {
+    slug: "rio-tinto-cfo",
+    name: "Sarah Mitchell",
+    initials: "SM",
+    title: "CFO, Copper Division",
+    org: "Rio Tinto",
+    bio: "Leads finance for Rio Tinto's global copper portfolio, including Oyu Tolgoi. Joined Rio Tinto in 2015 from BHP.",
+    expertise: ["Mining & Resources", "Capital Allocation"],
+  },
+  {
+    slug: "damdinnyam-g",
+    name: "Damdinnyam G.",
+    initials: "DG",
+    title: "Minister of Mining",
+    org: "Government of Mongolia",
+    bio: "Minister of Mining in the Uchral cabinet. Previously CEO of Erdenes Tavan Tolgoi. Architect of the 2026 royalty reform draft.",
+    expertise: ["Mining & Resources", "Policy & Regulation"],
+  },
+  {
+    slug: "namkhaidorj-b-speaker",
+    name: "Namkhaidorj B.",
+    initials: "NB",
+    title: "Senior Analyst",
+    org: "CMM",
+    bio: "CMM's senior analyst covering fixed income, deal structuring, and capital markets transactions. Co-author of the Mongolia DealBook series.",
+    expertise: ["Capital Markets", "Fixed Income"],
+  },
+  {
+    slug: "ariunzaya-o-speaker",
+    name: "Ariunzaya O.",
+    initials: "AO",
+    title: "Geopolitics & Minerals Analyst",
+    org: "CMM",
+    bio: "Covers critical minerals policy, international relations, and Mongolia's positioning in global supply chains.",
+    expertise: ["Mining & Resources", "Geopolitics", "ESG & Climate"],
+  },
+];
+
+/* ── News (Market Feed) ────────────────── */
+
+export type NewsCategory = "markets" | "companies" | "sectors" | "policy" | "deals" | "macro";
+
+export const NEWS_CATEGORY_LABELS: Record<NewsCategory, string> = {
+  markets: "Markets",
+  companies: "Companies",
+  sectors: "Sectors",
+  policy: "Policy",
+  deals: "Deals",
+  macro: "Macro",
+};
+
+export const NEWS_CATEGORY_COLORS: Record<NewsCategory, string> = {
+  markets: "var(--cat-markets)",
+  companies: "var(--cat-companies)",
+  sectors: "var(--cat-sectors)",
+  policy: "var(--brand-l)",
+  deals: "var(--cat-insights)",
+  macro: "var(--cat-ai)",
+};
+
+export interface MockNewsItem {
+  id: string;
+  headline: string;
+  summary?: string;
+  source: string;
+  sourceUrl?: string;
+  publishedAt: string;
+  category: NewsCategory;
+  topics?: string[];
+  entitySlugs: string[];
+  /** AI confidence score 0-1 from entity-matching pipeline */
+  confidence: number;
+  /** True when analyst has reviewed the AI tagging */
+  reviewed?: boolean;
+  isBreaking?: boolean;
+  imageUrl?: string;
+}
+
+export const MOCK_NEWS: MockNewsItem[] = [
+  {
+    id: "n-001",
+    headline: "MSE Top-20 Closes at 6-Month High on Banking Rally",
+    summary: "The benchmark gained 1.8% on the day, led by Khan Bank (+2.5%) and Golomt Bank (+1.2%). Volume hit MNT 12.4B, well above the 30-day average.",
+    source: "Bloomberg",
+    publishedAt: "2026-04-27T08:42:00Z",
+    category: "markets",
+    topics: ["Capital Markets", "Banking & Finance"],
+    entitySlugs: ["khan-bank", "golomt-bank", "mse"],
+    confidence: 0.94,
+    reviewed: true,
+    isBreaking: true,
+  },
+  {
+    id: "n-002",
+    headline: "Khan Bank Announces MNT 50B Bond Issuance for Infrastructure Lending",
+    summary: "Five-year senior secured note priced at 11.5%. Proceeds earmarked for power transmission and urban water projects.",
+    source: "Reuters",
+    publishedAt: "2026-04-27T07:15:00Z",
+    category: "deals",
+    topics: ["Banking & Finance", "Capital Markets"],
+    entitySlugs: ["khan-bank"],
+    confidence: 0.97,
+    reviewed: true,
+  },
+  {
+    id: "n-003",
+    headline: "Oyu Tolgoi Underground Phase 2 Reaches Production Milestone",
+    summary: "Rio Tinto announced first ore from Panel 2 ahead of schedule. Sustaining capex guidance held at $1.2B for 2026.",
+    source: "Mining.com",
+    publishedAt: "2026-04-27T05:30:00Z",
+    category: "companies",
+    topics: ["Mining & Resources"],
+    entitySlugs: ["oyu-tolgoi"],
+    confidence: 0.98,
+    reviewed: true,
+  },
+  {
+    id: "n-004",
+    headline: "Cabinet Approves Updated Mining Royalty Framework",
+    summary: "Draft amendments cap progressive surcharges at 18% for copper exports. Industry response cautiously positive; Erdenes Mongol awaiting written guidance.",
+    source: "Montsame",
+    publishedAt: "2026-04-26T22:00:00Z",
+    category: "policy",
+    topics: ["Mining & Resources", "Policy & Regulation"],
+    entitySlugs: ["oyu-tolgoi", "erdenet-mining"],
+    confidence: 0.91,
+    reviewed: true,
+  },
+  {
+    id: "n-005",
+    headline: "TDB Said to Mandate Banks for $500M Eurobond Roadshow",
+    summary: "Citi, JPMorgan, and Mizuho reportedly mandated for early-June marketing. Use-of-proceeds includes refinancing and Central Asian expansion capex.",
+    source: "Reuters",
+    publishedAt: "2026-04-26T18:45:00Z",
+    category: "deals",
+    topics: ["Banking & Finance", "Capital Markets"],
+    entitySlugs: ["tdb"],
+    confidence: 0.85,
+    reviewed: true,
+  },
+  {
+    id: "n-006",
+    headline: "Mongolia's March CPI Comes In at 11.8%, Below Consensus",
+    summary: "Headline inflation eased 30bps from February. Food prices remain the dominant driver. Bank of Mongolia next decision May 12.",
+    source: "FT",
+    publishedAt: "2026-04-26T14:20:00Z",
+    category: "macro",
+    topics: ["Economy & Macro"],
+    entitySlugs: [],
+    confidence: 0.99,
+    reviewed: true,
+  },
+  {
+    id: "n-007",
+    headline: "Ard App Crosses 2M Active Users, Doubles QoQ Transaction Volume",
+    summary: "Ard Financial Group's super-app reported 2.1M MAUs as of March. P2P transfer and merchant payments led growth.",
+    source: "Bloomberg",
+    publishedAt: "2026-04-26T11:00:00Z",
+    category: "companies",
+    topics: ["Technology", "Banking & Finance"],
+    entitySlugs: ["ard-financial-group"],
+    confidence: 0.92,
+    reviewed: true,
+  },
+  {
+    id: "n-008",
+    headline: "Erdenes Tavan Tolgoi IPO Roadmap Pushed to H2 2026",
+    summary: "MSE listing now targeted for September. Working group cites pending royalty framework as the main schedule risk.",
+    source: "CMM Research",
+    publishedAt: "2026-04-26T09:30:00Z",
+    category: "companies",
+    topics: ["Capital Markets", "Mining & Resources", "State-Owned Enterprises"],
+    entitySlugs: ["tavan-tolgoi", "erdenet-mining"],
+    confidence: 0.78,
+  },
+  {
+    id: "n-009",
+    headline: "Coking Coal Spot Hits 14-Month Low on China Steel Demand",
+    summary: "Newcastle benchmark fell to $186/t. Mongolian exporters face additional pressure from rail capacity constraints at Gashuunsukhait.",
+    source: "Mining.com",
+    publishedAt: "2026-04-25T16:10:00Z",
+    category: "sectors",
+    topics: ["Mining & Resources", "Trade & Geopolitics"],
+    entitySlugs: ["tavan-tolgoi"],
+    confidence: 0.87,
+    reviewed: true,
+  },
+  {
+    id: "n-010",
+    headline: "Tsakhia Solar Park Achieves Financial Close",
+    summary: "100MW project reached financial close with $92M senior facility led by ADB. Commissioning targeted Q3 2026.",
+    source: "Reuters",
+    publishedAt: "2026-04-25T13:45:00Z",
+    category: "deals",
+    topics: ["Energy", "ESG & Climate"],
+    entitySlugs: ["tsakhia-solar", "newcom-group"],
+    confidence: 0.95,
+    reviewed: true,
+  },
+  {
+    id: "n-011",
+    headline: "FMO Commits Additional $50M to Mongolian Green Finance Pipeline",
+    summary: "Top-up follows the original $150M facility announced in January. Khan Bank and TDB are the lead intermediaries.",
+    source: "Bloomberg",
+    publishedAt: "2026-04-25T10:00:00Z",
+    category: "deals",
+    topics: ["ESG & Climate", "Banking & Finance"],
+    entitySlugs: ["khan-bank", "tdb"],
+    confidence: 0.93,
+    reviewed: true,
+  },
+  {
+    id: "n-012",
+    headline: "Gobi Cashmere Q1 Revenue Up 14% on Premium Channel Growth",
+    summary: "Direct-to-consumer revenue grew 32% YoY. EBITDA margin expanded 180bps to 18.4%.",
+    source: "Bloomberg",
+    publishedAt: "2026-04-24T15:30:00Z",
+    category: "companies",
+    topics: ["Agriculture"],
+    entitySlugs: ["gobi-cashmere"],
+    confidence: 0.96,
+    reviewed: true,
+  },
+  {
+    id: "n-013",
+    headline: "MSE to Pilot T+2 Settlement in June",
+    summary: "Mongolian Stock Exchange announced phase 1 of its settlement modernization program. Initial scope covers MSE Top-20 constituents.",
+    source: "Montsame",
+    publishedAt: "2026-04-24T11:15:00Z",
+    category: "policy",
+    topics: ["Capital Markets"],
+    entitySlugs: ["mse"],
+    confidence: 0.89,
+    reviewed: true,
+  },
+  {
+    id: "n-014",
+    headline: "Aspire Mining Closes A$15M Placement, Resumes Ovoot Drilling",
+    summary: "Funds support an extended drill campaign at the Ovoot Coking Coal Project. Lead manager: Canaccord Genuity.",
+    source: "Mining.com",
+    publishedAt: "2026-04-24T08:20:00Z",
+    category: "deals",
+    topics: ["Mining & Resources", "Capital Markets"],
+    entitySlugs: ["aspire-mining"],
+    confidence: 0.94,
+    reviewed: true,
+  },
+  {
+    id: "n-015",
+    headline: "Bank of Mongolia Holds Policy Rate at 12%",
+    summary: "Statement cited persistent food-price inflation and tugrik volatility. Next meeting May 12.",
+    source: "FT",
+    publishedAt: "2026-04-23T17:00:00Z",
+    category: "policy",
+    topics: ["Economy & Macro", "Banking & Finance"],
+    entitySlugs: [],
+    confidence: 0.99,
+    reviewed: true,
+  },
+  {
+    id: "n-016",
+    headline: "Mongolian Properties Reports First-Quarter Pre-Sales of MNT 84B",
+    summary: "Pre-sales tracked above plan. Three new projects targeted for Q3 launch in UB.",
+    source: "CMM Research",
+    publishedAt: "2026-04-23T12:00:00Z",
+    category: "companies",
+    topics: ["Real Estate & Infrastructure"],
+    entitySlugs: [],
+    confidence: 0.62,
+  },
+  {
+    id: "n-017",
+    headline: "Newcom & Korean Consortium Sign MoU for Wind Project",
+    summary: "150MW wind farm in Sainshand. PPA framework under negotiation with Central Grid.",
+    source: "Reuters",
+    publishedAt: "2026-04-22T20:30:00Z",
+    category: "sectors",
+    topics: ["Energy", "ESG & Climate"],
+    entitySlugs: ["newcom-group"],
+    confidence: 0.83,
+    reviewed: true,
+  },
+  {
+    id: "n-018",
+    headline: "Mandal Insurance Net Income Up 22% on Non-Life Premium Growth",
+    summary: "Combined ratio improved to 92.3%. Investment income held flat YoY.",
+    source: "Bloomberg",
+    publishedAt: "2026-04-22T14:00:00Z",
+    category: "companies",
+    topics: ["Banking & Finance"],
+    entitySlugs: ["mandal-insurance"],
+    confidence: 0.95,
+    reviewed: true,
+  },
+  {
+    id: "n-019",
+    headline: "Parliament Approves 2026 Supplementary Budget",
+    summary: "MNT 1.2T supplementary budget passed final reading. Allocations weighted toward energy infrastructure and pension top-ups.",
+    source: "Montsame",
+    publishedAt: "2026-04-22T09:45:00Z",
+    category: "policy",
+    topics: ["Policy & Regulation", "Economy & Macro"],
+    entitySlugs: [],
+    confidence: 0.88,
+    reviewed: true,
+  },
+  {
+    id: "n-020",
+    headline: "M Bank Reports Strong Trade Finance Demand From Mid-Cap Importers",
+    summary: "Trade finance book grew 18% YoY in Q1. NIM held at 3.9%.",
+    source: "CMM Research",
+    publishedAt: "2026-04-21T16:30:00Z",
+    category: "companies",
+    topics: ["Banking & Finance"],
+    entitySlugs: [],
+    confidence: 0.71,
+  },
+];


### PR DESCRIPTION
## Summary

Week 5 of the MarketIQ v1 plan — ships Events, Market Feed, Concierge, and the Account Portal as static pages backed by mock data.

- **Events**: `/events` (landing), `/events/[slug]` (agenda + registration), `/events/past`, `/events/speakers/[slug]`
- **Market Feed**: `/feed` (category + source + confidence filters, time-grouped sticky headers), `/feed/[id]` (news detail w/ linked entities + related coverage)
- **Concierge**: `/concierge` connection request flow + confirmation
- **Account Portal**: `/account` tabbed view (saved insights, registered events, concierge requests, alerts placeholder, profile)
- **Insights**: lock V1 (No Hero + Tags) layout, remove the variant switcher
- **Sticky polish**: section headers + sidebars stick on `/events`, `/events/past`, `/events/[slug]`, `/events/speakers/[slug]`, `/feed`, `/feed/[id]`

All data still mocked in `app/lib/mock-data.ts` — `MOCK_EVENTS` (6), `MOCK_SPEAKERS` (7), `MOCK_NEWS` (20). Wires up to backend later.

## Test plan

- [ ] `npm run build` passes
- [ ] `/events` — featured + grid + past teaser, sticky section headers
- [ ] `/events/mif-2026` — agenda, speakers, sponsors, registration form (success state on submit)
- [ ] `/events/past` — events grouped by year
- [ ] `/events/speakers/uchral-n` — bio, sessions, sticky Connect sidebar
- [ ] `/feed` — category tabs swap H1, source/confidence filters work, time groups stick on scroll, sidebar sticks
- [ ] `/feed/n-001` — news detail with linked entities + related coverage
- [ ] `/concierge` — request type pills + sector tags + form submit → success state
- [ ] `/account` — tabs: Saved / Events / Requests / Alerts / Profile
- [ ] `/insights` — V1 layout only (no switcher visible)