### PR TITLE
directory + entity profile: variant switchers + filter polish

### DIFF
--- a/app/components/directory/entity-card.tsx
+++ b/app/components/directory/entity-card.tsx
@@ -2,19 +2,6 @@ import Link from "next/link";
 import { cn } from "@/app/lib/cn";
 import type { MockEntity } from "@/app/lib/mock-data";
 
-/* ── Sector badge mapping (muted, standard) ── */
-
-const SECTOR_BADGE: Record<string, string> = {
-  "Mining & Resources": "badge-sectors",
-  "Banking & Finance": "badge-companies",
-  "Capital Markets": "badge-markets",
-  "Energy": "badge-insights",
-  "Technology": "badge-ai",
-  "Real Estate & Infrastructure": "badge-companies",
-  "Agriculture": "badge-sectors",
-  "Professional Services": "badge-markets",
-};
-
 /* ── EntityCard ───────────────────────────── */
 
 export function EntityCard({ entity }: { entity: MockEntity }) {
@@ -50,27 +37,30 @@ export function EntityCard({ entity }: { entity: MockEntity }) {
             {entity.name}
           </h3>
 
-          {hasTicker && entity.price != null && (
-            <div className="flex items-center gap-1.5 mt-0.5">
-              <span className="font-mono text-xs text-fg-3">
-                {entity.ticker}
-              </span>
-              <span className="font-mono text-xs font-medium text-fg">
-                {entity.price.toLocaleString()}
-              </span>
-              {entity.changePercent != null && (
-                <span
-                  className={cn(
-                    "font-mono text-xs font-medium",
-                    entity.changePercent >= 0 ? "text-pos" : "text-neg"
-                  )}
-                >
-                  {entity.changePercent >= 0 ? "+" : ""}
-                  {entity.changePercent}%
+          {/* Stats row — always reserves space so cards with/without stats match height */}
+          <div className="flex items-center gap-1.5 mt-0.5 h-[18px]">
+            {hasTicker && entity.price != null && (
+              <>
+                <span className="font-mono text-xs text-fg-3">
+                  {entity.ticker}
                 </span>
-              )}
-            </div>
-          )}
+                <span className="font-mono text-xs font-medium text-fg">
+                  {entity.price.toLocaleString()}
+                </span>
+                {entity.changePercent != null && (
+                  <span
+                    className={cn(
+                      "font-mono text-xs font-medium",
+                      entity.changePercent >= 0 ? "text-pos" : "text-neg"
+                    )}
+                  >
+                    {entity.changePercent >= 0 ? "+" : ""}
+                    {entity.changePercent}%
+                  </span>
+                )}
+              </>
+            )}
+          </div>
         </div>
       </div>
 
@@ -79,18 +69,16 @@ export function EntityCard({ entity }: { entity: MockEntity }) {
         {entity.description}
       </p>
 
-      {/* Badges — sector + raising only (type comes from section context) */}
-      <div className="flex gap-1 mt-2.5 flex-wrap">
-        <span
-          className={cn(
-            "badge",
-            SECTOR_BADGE[entity.sector] ?? "badge-markets"
-          )}
-        >
+      {/* Tags — muted sector pill + highlighted raising pill (type comes from section context) */}
+      <div className="flex gap-1.5 mt-2.5 flex-wrap">
+        <span className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2">
           {entity.sector}
         </span>
         {entity.isRaising && (
-          <span className="badge badge-signal">Raising</span>
+          <span className="inline-flex items-center gap-1.5 font-body font-semibold text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-brand text-[var(--brand-t)]">
+            <span className="w-1.5 h-1.5 rounded-full bg-[var(--brand-t)] animate-pulse" />
+            Raising
+          </span>
         )}
       </div>
     </Link>

--- a/app/components/entity/entity-header.tsx
+++ b/app/components/entity/entity-header.tsx
@@ -188,6 +188,12 @@ interface EntityHeaderProps {
   website?: string;
   foreignBlocker?: React.ReactNode;
   className?: string;
+  /* v1 = CTAs in header, tags + socials in meta row (default).
+     v2 = CTAs hoisted to sidebar by parent; tags + socials demoted to footer row under description.
+     v3 = Editorial layout: kicker row, big bold name with price callout right, larger brief, footer meta. No logo block. */
+  variant?: "v1" | "v2" | "v3";
+  /* Slim sticky-scroll mode (used by V1 only). Renders a single-row bar with logo, name, ticker/price, CTAs. */
+  compact?: boolean;
 
   /* Crunchbase-style meta row data */
   marketCap?: string;
@@ -235,7 +241,64 @@ export function EntityHeader({
   languagesCount,
   practiceAreas,
   socialLinks,
+  variant = "v1",
+  compact = false,
 }: EntityHeaderProps) {
+  const isV2 = variant === "v2";
+  const isV3 = variant === "v3";
+
+  /* ── Compact (sticky-scroll) mode ─────────────── */
+  if (compact) {
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-3 min-w-0",
+          className,
+        )}
+      >
+        <div
+          className="w-9 h-9 rounded-[var(--btn-r)] flex items-center justify-center font-display font-extrabold text-sm text-brand-l shrink-0"
+          style={{
+            background:
+              "linear-gradient(135deg, var(--brand-m), var(--surface-el))",
+          }}
+        >
+          {initials}
+        </div>
+        <span className="font-display font-extrabold text-sm tracking-tight text-fg leading-none truncate">
+          {name}
+        </span>
+        {exchange && ticker && (
+          <span className="font-mono font-medium text-xs text-fg-3 tracking-[0.02em] shrink-0 max-md:hidden">
+            {exchange}: {ticker}
+          </span>
+        )}
+        {price && (
+          <span className="font-mono font-semibold text-sm text-fg shrink-0 max-md:hidden">
+            {price}
+          </span>
+        )}
+        {priceChange && (
+          <span
+            className={cn(
+              "font-mono font-semibold text-xs shrink-0 max-md:hidden",
+              priceDirection === "up" ? "text-pos" : "text-neg",
+            )}
+          >
+            {priceChange} {priceDirection === "up" ? "↑" : "↓"}
+          </span>
+        )}
+        <div className="flex gap-2 ml-auto shrink-0">
+          <button className="btn btn-secondary text-xs py-1.5 px-3 max-sm:hidden">
+            Add to Watchlist
+          </button>
+          <button className="btn btn-signal text-xs py-1.5 px-3">
+            Request Connection
+          </button>
+        </div>
+      </div>
+    );
+  }
   /* Practice areas truncation: first 2 + "+N more" */
   let practiceAreasLabel: string | undefined;
   if (practiceAreas && practiceAreas.length > 0) {
@@ -250,7 +313,7 @@ export function EntityHeader({
      Separator dots are interleaved so missing fields don't leave orphan dots. */
   const metaNodes: React.ReactNode[] = [];
 
-  if (dataSource) metaNodes.push(<ProfileBadgeWidget key="cmm" dataSource={dataSource} />);
+  if (dataSource && !isV2) metaNodes.push(<ProfileBadgeWidget key="cmm" dataSource={dataSource} />);
 
   if (exchange && ticker) {
     metaNodes.push(
@@ -285,23 +348,26 @@ export function EntityHeader({
     );
   }
 
-  metaNodes.push(
+  const typePill = (
     <span
       key="type"
       className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2"
     >
       {type}
-    </span>,
+    </span>
   );
 
-  metaNodes.push(
+  const sectorPill = (
     <span
       key="sector"
       className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2"
     >
       {sector}
-    </span>,
+    </span>
   );
+
+  metaNodes.push(typePill);
+  metaNodes.push(sectorPill);
 
   if (yearEstablished) {
     metaNodes.push(
@@ -355,12 +421,14 @@ export function EntityHeader({
     );
   }
 
-  if (website) {
-    metaNodes.push(
-      <MetaItem key="web" icon={<Icons.Globe />} href={website}>
-        {website.replace(/^https?:\/\//, "").replace(/\/$/, "")}
-      </MetaItem>,
-    );
+  const websiteNode = website ? (
+    <MetaItem key="web" icon={<Icons.Globe />} href={website}>
+      {website.replace(/^https?:\/\//, "").replace(/\/$/, "")}
+    </MetaItem>
+  ) : null;
+
+  if (websiteNode) {
+    metaNodes.push(websiteNode);
   }
 
   /* Socials cluster as a single trailing group with no internal separators */
@@ -395,6 +463,103 @@ export function EntityHeader({
     interleaved.push(node);
   });
 
+  /* ── V3: Editorial layout ───────────────────────── */
+  if (isV3) {
+    /* Footer meta: location/founded/raising/practice/website/socials. Exclude pricing + tags. */
+    const v3FooterNodes = metaNodes.filter((n) => {
+      const key = (n as { key?: string | null })?.key;
+      return (
+        key !== "type" &&
+        key !== "sector" &&
+        key !== "cmm" &&
+        key !== "ticker" &&
+        key !== "price" &&
+        key !== "change"
+      );
+    });
+    const v3FooterInterleaved: React.ReactNode[] = [];
+    v3FooterNodes.forEach((node, i) => {
+      if (i > 0) v3FooterInterleaved.push(<MetaSep key={`v3-sep-${i}`} />);
+      v3FooterInterleaved.push(node);
+    });
+
+    return (
+      <div className={cn("pb-10 border-b-2 border-border mb-10", className)}>
+        {/* Kicker bar — colored marker + type · sector caps + CMM badge anchored right */}
+        <div className="flex items-center gap-3 pb-4 mb-7 border-b border-border-s flex-wrap">
+          <div className="w-1 h-4 bg-brand rounded-[1px]" />
+          <span className="font-mono text-xs uppercase tracking-[0.16em] font-semibold text-fg">
+            {type}
+          </span>
+          <span className="text-fg-3 font-mono">·</span>
+          <span className="font-mono text-xs uppercase tracking-[0.16em] text-fg-2">
+            {sector}
+          </span>
+          {dataSource && (
+            <div className="ml-auto">
+              <ProfileBadgeWidget dataSource={dataSource} />
+            </div>
+          )}
+        </div>
+
+        {/* Hero: 2-column — big name + dek on left, anchored stat card on right */}
+        <div className="grid grid-cols-[1fr_300px] gap-12 items-start max-lg:grid-cols-[1fr_260px] max-md:grid-cols-1 max-md:gap-6">
+          {/* Left column: name + dek */}
+          <div className="flex flex-col gap-5">
+            <h1 className="font-display font-extrabold text-[64px] tracking-[-0.02em] leading-[0.95] text-fg max-lg:text-5xl max-md:text-4xl">
+              {name}
+            </h1>
+            {description && (
+              <p className="font-display font-medium text-xl leading-[1.4] text-fg-2 max-w-[60ch] max-md:text-lg">
+                {description}
+              </p>
+            )}
+          </div>
+
+          {/* Right column: bordered stat card — only shown if there's pricing data */}
+          {(price || (exchange && ticker)) && (
+            <div className="border border-border bg-surface rounded-[var(--card-r)] p-5 flex flex-col gap-4 max-md:max-w-[320px]">
+              {exchange && ticker && (
+                <div className="font-mono text-[11px] uppercase tracking-[0.1em] font-semibold text-fg-3 pb-3 border-b border-border-s">
+                  {exchange}: {ticker}
+                </div>
+              )}
+              {price && (
+                <div className="flex flex-col gap-1">
+                  <span className="font-display text-[10px] uppercase tracking-[0.1em] font-semibold text-fg-3">
+                    Price
+                  </span>
+                  <span className="font-mono font-bold text-[32px] text-fg leading-none tabular-nums">
+                    {price}
+                  </span>
+                  {priceChange && (
+                    <span
+                      className={cn(
+                        "font-mono font-semibold text-sm tabular-nums",
+                        priceDirection === "up" ? "text-pos" : "text-neg",
+                      )}
+                    >
+                      {priceChange} {priceDirection === "up" ? "↑" : "↓"}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Byline meta row */}
+        {v3FooterInterleaved.length > 0 && (
+          <div className="flex items-center gap-x-3 gap-y-1.5 flex-wrap pt-7 mt-7 border-t border-border-s">
+            {v3FooterInterleaved}
+          </div>
+        )}
+
+        {foreignBlocker && <div className="pt-4">{foreignBlocker}</div>}
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -404,7 +569,12 @@ export function EntityHeader({
     >
       {/* Logo / Initials */}
       <div
-        className="w-28 h-28 min-w-28 rounded-[var(--card-r)] flex items-center justify-center font-display font-extrabold text-3xl text-brand-l shrink-0"
+        className={cn(
+          "rounded-[var(--card-r)] flex items-center justify-center font-display font-extrabold text-brand-l shrink-0",
+          isV2
+            ? "w-40 self-stretch min-h-40 text-5xl max-md:w-28 max-md:h-28 max-md:min-h-0 max-md:self-auto max-md:text-3xl"
+            : "w-28 h-28 min-w-28 text-3xl",
+        )}
         style={{
           background:
             "linear-gradient(135deg, var(--brand-m), var(--surface-el))",
@@ -420,24 +590,34 @@ export function EntityHeader({
           <h1 className="font-display font-extrabold text-3xl tracking-tight text-fg leading-heading">
             {name}
           </h1>
-          <div className="flex gap-2 ml-auto max-md:ml-0 max-md:w-full">
-            <button className="btn btn-secondary text-sm">Add to Watchlist</button>
-            <button className="btn btn-signal text-sm">Request Connection</button>
-          </div>
+          {isV2 && dataSource && <ProfileBadgeWidget dataSource={dataSource} />}
+          {!isV2 && (
+            <div className="flex gap-2 ml-auto max-md:ml-0 max-md:w-full">
+              <button className="btn btn-secondary text-sm">Add to Watchlist</button>
+              <button className="btn btn-signal text-sm">Request Connection</button>
+            </div>
+          )}
         </div>
 
-        {/* Row 2: combined meta row (ticker/price + Crunchbase-style icon-pairs) */}
-        {interleaved.length > 0 && (
+        {/* Meta row above description (V1) */}
+        {!isV2 && interleaved.length > 0 && (
           <div className="flex items-center gap-x-3 gap-y-1.5 flex-wrap">
             {interleaved}
           </div>
         )}
 
-        {/* Row 4: Description */}
+        {/* Description */}
         {description && (
-          <p className="text-sm text-fg-2 leading-relaxed">
+          <p className={cn("text-fg-2 leading-relaxed", isV2 ? "text-base" : "text-sm")}>
             {description}
           </p>
+        )}
+
+        {/* Meta row below description (V2) — full stats + tags + website + socials */}
+        {isV2 && interleaved.length > 0 && (
+          <div className="flex items-center gap-x-3 gap-y-1.5 flex-wrap pt-1">
+            {interleaved}
+          </div>
         )}
 
         {foreignBlocker && <div className="pt-1">{foreignBlocker}</div>}

--- a/app/directory/[slug]/page.tsx
+++ b/app/directory/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
-  EntityHeader,
   MarketDataWidget,
   FinancialTableWidget,
   KeyPersonnelWidget,
@@ -24,6 +23,7 @@ import {
   ENTITY_TYPE_LABELS,
   type MockEntity,
 } from "@/app/lib/mock-data";
+import { ProfileVariants } from "./profile-variants";
 
 /* ═══════════════════════════════════════════════════════════
    Entity Profile — /directory/[slug]
@@ -265,19 +265,10 @@ export default async function EntityProfilePage({ params }: PageProps) {
     },
   ].filter(Boolean) as { id: string; label: string }[];
 
-  return (
-    <div className="max-w-[var(--content-max)] mx-auto px-6 w-full py-0">
-      {/* Entity Header */}
-      <div className="pt-6">
-        <EntityHeader {...headerProps} />
-      </div>
-
-      {/* Two-column layout */}
-      <div className="grid grid-cols-[1fr_340px] gap-12 pb-20 items-start max-lg:grid-cols-1 max-lg:gap-6">
-        {/* ── Main column ── */}
-        <div className="flex flex-col gap-5 min-w-0">
-          {/* Sector taxonomy blocker — kept for non-public types while spec firms up */}
-          {!isPublic && (
+  const mainContent = (
+    <>
+      {/* Sector taxonomy blocker — kept for non-public types while spec firms up */}
+      {!isPublic && (
             <BlockerLabel owner="Namkhai / Zoloo" variant="block">
               Sector taxonomy is not yet finalized. The current sector tag
               (&quot;{entity.sector}&quot;) uses the placeholder vocabulary. Final category list
@@ -533,24 +524,31 @@ export default async function EntityProfilePage({ params }: PageProps) {
               </div>
             </section>
           )}
-        </div>
+    </>
+  );
 
-        {/* ── Sticky sidebar ── */}
-        <aside className="lg:sticky lg:top-[80px] flex flex-col gap-5 max-lg:grid max-lg:grid-cols-2 max-md:grid-cols-1">
-          {tocItems.length > 0 && <ArticleSidebar toc={tocItems} />}
-          {showConnection && (
-            <RequestConnectionWidget entityName={entity.name} loggedIn={false} />
-          )}
-          <DownloadsWidget
-            reports={entity.reports}
-            pitchDecks={entity.pitchDecks}
-            sustainabilityDocs={entity.sustainabilityDocs}
-            investmentTeasers={entity.investmentTeasers}
-            operationalDocs={entity.operationalDocs}
-            requiresAuth
-          />
-        </aside>
-      </div>
-    </div>
+  const sidebarContent = (
+    <>
+      {tocItems.length > 0 && <ArticleSidebar toc={tocItems} />}
+      {showConnection && (
+        <RequestConnectionWidget entityName={entity.name} loggedIn={false} />
+      )}
+      <DownloadsWidget
+        reports={entity.reports}
+        pitchDecks={entity.pitchDecks}
+        sustainabilityDocs={entity.sustainabilityDocs}
+        investmentTeasers={entity.investmentTeasers}
+        operationalDocs={entity.operationalDocs}
+        requiresAuth
+      />
+    </>
+  );
+
+  return (
+    <ProfileVariants
+      headerProps={headerProps}
+      mainContent={mainContent}
+      sidebarContent={sidebarContent}
+    />
   );
 }

--- a/app/directory/[slug]/profile-variants.tsx
+++ b/app/directory/[slug]/profile-variants.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useRef, useState, type ComponentProps, type ReactNode } from "react";
+import { EntityHeader } from "@/app/components/entity";
+import { cn } from "@/app/lib/cn";
+
+type Variant = "v1" | "v2" | "v3";
+
+const VARIANTS: { value: Variant; label: string }[] = [
+  { value: "v1", label: "Crunchbase" },
+  { value: "v2", label: "V2 — Sidebar CTAs" },
+  { value: "v3", label: "V3 — Editorial" },
+];
+
+interface ProfileVariantsProps {
+  headerProps: Omit<ComponentProps<typeof EntityHeader>, "variant">;
+  mainContent: ReactNode;
+  sidebarContent: ReactNode;
+}
+
+export function ProfileVariants({
+  headerProps,
+  mainContent,
+  sidebarContent,
+}: ProfileVariantsProps) {
+  const [variant, setVariant] = useState<Variant>("v1");
+  const [showCompactBar, setShowCompactBar] = useState(false);
+  const fullHeaderRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (variant !== "v1") {
+      setShowCompactBar(false);
+      return;
+    }
+    const el = fullHeaderRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowCompactBar(!entry.isIntersecting),
+      { rootMargin: "-56px 0px 0px 0px", threshold: 0 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [variant]);
+
+  return (
+    <>
+      {/* Sticky compact bar (V1 only) — slides in once the full header scrolls out of view */}
+      {variant === "v1" && (
+        <div
+          className={cn(
+            "fixed top-[var(--header-h)] left-0 right-0 z-30 bg-[var(--bg)] border-b border-border-s transition-transform duration-200 ease-out",
+            showCompactBar ? "translate-y-0" : "-translate-y-full",
+          )}
+        >
+          <div className="max-w-[var(--content-max)] mx-auto px-6 w-full py-2">
+            <EntityHeader {...headerProps} variant="v1" compact />
+          </div>
+        </div>
+      )}
+
+      <div className="max-w-[var(--content-max)] mx-auto px-6 w-full py-0">
+        <div ref={fullHeaderRef} className="pt-6">
+          <EntityHeader {...headerProps} variant={variant} />
+        </div>
+
+        <div
+          className={cn(
+            "grid gap-5 pb-20 items-start max-lg:grid-cols-1",
+            variant === "v1"
+              ? "grid-cols-[340px_1fr]"
+              : "grid-cols-[1fr_340px]",
+          )}
+        >
+          <div
+            className={cn(
+              "flex flex-col gap-5 min-w-0",
+              variant === "v1" && "lg:order-2",
+            )}
+          >
+            {mainContent}
+          </div>
+
+          <aside
+            className={cn(
+              "lg:sticky lg:top-[80px] flex flex-col gap-5 max-lg:grid max-lg:grid-cols-2 max-md:grid-cols-1",
+              variant === "v1" && "lg:order-1",
+            )}
+          >
+            {(variant === "v2" || variant === "v3") && (
+              <div className="widget">
+                <div className="widget-body flex flex-col gap-2">
+                  <button className="btn btn-secondary text-sm w-full">
+                    Add to Watchlist
+                  </button>
+                  <button className="btn btn-signal text-sm w-full">
+                    Request Connection
+                  </button>
+                </div>
+              </div>
+            )}
+            {sidebarContent}
+          </aside>
+        </div>
+      </div>
+
+      {/* Floating variant switcher (bottom-center) */}
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 p-1 rounded-[var(--btn-r)] border border-border bg-[var(--white)] shadow-lg">
+        {VARIANTS.map((v) => (
+          <button
+            key={v.value}
+            onClick={() => setVariant(v.value)}
+            className={cn(
+              "px-3 py-1.5 rounded-[var(--btn-r)] text-xs font-display font-semibold cursor-pointer transition-all duration-[200ms] border-none",
+              variant === v.value
+                ? "bg-brand text-white"
+                : "bg-transparent text-fg-2 hover:text-brand",
+            )}
+          >
+            {v.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/app/directory/directory-controls.tsx
+++ b/app/directory/directory-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { EntityCard } from "@/app/components/directory/entity-card";
 import { cn } from "@/app/lib/cn";
 import type { MockEntity } from "@/app/lib/mock-data";
@@ -43,6 +43,151 @@ function writeParams(state: {
   window.history.replaceState(null, "", str ? `?${str}` : window.location.pathname);
 }
 
+/* ── Sector dropdown ─────────────────────── */
+
+function SectorDropdown({
+  value,
+  onChange,
+  options,
+}: {
+  value: string | null;
+  onChange: (value: string | null) => void;
+  options: readonly string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number; minWidth: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  /* Recompute panel position any time it opens or the viewport changes */
+  useEffect(() => {
+    if (!open) {
+      setPos(null);
+      return;
+    }
+    const update = () => {
+      const el = triggerRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setPos({ top: r.bottom + 6, left: r.left, minWidth: Math.max(r.width, 220) });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open]);
+
+  /* Click-outside + Escape */
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (
+        triggerRef.current && !triggerRef.current.contains(t) &&
+        panelRef.current && !panelRef.current.contains(t)
+      ) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const label = value ?? "All Sectors";
+  const active = !!value;
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={triggerRef}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "flex items-center gap-2 px-3 py-1.5 rounded-[var(--btn-r)] border text-sm font-display font-semibold cursor-pointer transition-all duration-[200ms] whitespace-nowrap",
+          active
+            ? "border-transparent bg-brand-m text-brand"
+            : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l",
+        )}
+      >
+        <span>{label}</span>
+        <svg
+          className={cn(
+            "transition-transform duration-200",
+            open && "rotate-180",
+          )}
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && pos && (
+        <div
+          ref={panelRef}
+          style={{ position: "fixed", top: pos.top, left: pos.left, minWidth: pos.minWidth }}
+          className="z-[100] py-1 rounded-[var(--card-r)] border border-border bg-[var(--white)] shadow-lg max-h-[320px] overflow-y-auto scrollbar-none"
+        >
+          <button
+            type="button"
+            onClick={() => {
+              onChange(null);
+              setOpen(false);
+            }}
+            className={cn(
+              "flex items-center w-full text-left px-3 py-2 text-sm font-medium cursor-pointer transition-colors border-none",
+              !active
+                ? "bg-brand-m text-brand font-semibold"
+                : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg",
+            )}
+          >
+            All Sectors
+          </button>
+          <div className="h-px bg-border-s my-1" />
+          {options.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => {
+                onChange(s);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex items-center gap-2 w-full text-left px-3 py-2 text-sm font-medium cursor-pointer transition-colors border-none",
+                value === s
+                  ? "bg-brand-m text-brand font-semibold"
+                  : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg",
+              )}
+            >
+              <span
+                className={cn(
+                  "w-1.5 h-1.5 rounded-full shrink-0 transition-colors",
+                  value === s ? "bg-brand" : "bg-fg-3",
+                )}
+              />
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
 /* ── Search icon ─────────────────────────── */
 
 function SearchIcon() {
@@ -71,6 +216,13 @@ interface DirectoryControlsProps {
   entities: MockEntity[];
 }
 
+type LayoutVariant = "v1" | "v2";
+
+const LAYOUT_OPTIONS: { value: LayoutVariant; label: string }[] = [
+  { value: "v1", label: "V1 — Drawer" },
+  { value: "v2", label: "V2 — Inline Filters" },
+];
+
 export function DirectoryControls({ entities }: DirectoryControlsProps) {
   const [search, setSearch] = useState("");
   const [type, setType] = useState("all");
@@ -78,6 +230,7 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
   const [raising, setRaising] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const [layout, setLayout] = useState<LayoutVariant>("v1");
 
   /* Hydrate from URL on mount */
   useEffect(() => {
@@ -159,8 +312,8 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
 
   return (
     <>
-      {/* Slide-in drawer + backdrop */}
-      {drawerOpen && (
+      {/* Slide-in drawer + backdrop (V1 only) */}
+      {layout === "v1" && drawerOpen && (
         <div
           className="fixed inset-0 z-[60] bg-black/30"
           onClick={() => setDrawerOpen(false)}
@@ -171,7 +324,7 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
           "fixed top-0 left-0 z-[61] h-full w-[340px] max-w-[85vw] bg-[var(--white)] border-r border-border shadow-xl",
           "flex flex-col",
           "transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
-          drawerOpen ? "translate-x-0" : "-translate-x-full"
+          layout === "v1" && drawerOpen ? "translate-x-0" : "-translate-x-full"
         )}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border-s shrink-0">
@@ -279,67 +432,149 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
         </p>
       </div>
 
-      {/* Top bar */}
-      <div className="flex items-center justify-between gap-4 mb-6 flex-wrap">
-        <div className="flex items-center gap-3 flex-wrap">
-          <button
-            onClick={() => setDrawerOpen(true)}
-            className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-[var(--btn-r)] border text-sm font-display font-semibold cursor-pointer transition-all duration-[200ms]",
-              hasFilters
-                ? "border-brand bg-brand-m text-brand"
-                : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l"
-            )}
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
-              <line x1="4" y1="6" x2="20" y2="6" />
-              <line x1="4" y1="12" x2="14" y2="12" />
-              <line x1="4" y1="18" x2="10" y2="18" />
-            </svg>
-            Filters
-            {activeCount > 0 && (
-              <span className="w-5 h-5 rounded-full bg-brand text-white text-[10px] font-bold grid place-items-center">
-                {activeCount}
+      {/* ── V1: drawer-trigger top bar ─────────────────── */}
+      {layout === "v1" && (
+        <div className="flex items-center justify-between gap-4 mb-6 flex-wrap">
+          <div className="flex items-center gap-3 flex-wrap">
+            <button
+              onClick={() => setDrawerOpen(true)}
+              className={cn(
+                "flex items-center gap-2 px-3 py-1.5 rounded-[var(--btn-r)] border text-sm font-display font-semibold cursor-pointer transition-all duration-[200ms]",
+                hasFilters
+                  ? "border-brand bg-brand-m text-brand"
+                  : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l"
+              )}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+                <line x1="4" y1="6" x2="20" y2="6" />
+                <line x1="4" y1="12" x2="14" y2="12" />
+                <line x1="4" y1="18" x2="10" y2="18" />
+              </svg>
+              Filters
+              {activeCount > 0 && (
+                <span className="w-5 h-5 rounded-full bg-brand text-white text-[10px] font-bold grid place-items-center">
+                  {activeCount}
+                </span>
+              )}
+            </button>
+
+            {type !== "all" && (
+              <span className="flex items-center gap-1.5 text-xs font-medium text-brand bg-brand-m px-2.5 py-1 rounded-[var(--btn-r)]">
+                {ENTITY_TYPE_LABELS[type as keyof typeof ENTITY_TYPE_LABELS]}
+                <button onClick={() => setType("all")} className="text-brand hover:text-brand-h cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
               </span>
             )}
+            {sector && (
+              <span className="flex items-center gap-1.5 text-xs font-medium text-brand bg-brand-m px-2.5 py-1 rounded-[var(--btn-r)]">
+                {sector}
+                <button onClick={() => setSector(null)} className="text-brand hover:text-brand-h cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
+              </span>
+            )}
+            {raising && (
+              <span className="flex items-center gap-1.5 text-xs font-medium text-signal-h bg-signal-m px-2.5 py-1 rounded-[var(--btn-r)]">
+                <span className="w-1.5 h-1.5 rounded-full bg-signal" />
+                Actively Raising
+                <button onClick={() => setRaising(false)} className="text-signal-h hover:text-signal cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
+              </span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3">
+            <div className="relative w-[280px] max-md:w-full">
+              <SearchIcon />
+              <input
+                type="text"
+                placeholder="Search by name, ticker..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="input !pl-9"
+              />
+            </div>
+            <span className="text-xs text-fg-3 font-mono whitespace-nowrap">{total} results</span>
+          </div>
+        </div>
+      )}
+
+      {/* ── V2: inline filter bar — single row ── */}
+      {layout === "v2" && (
+        <div className="flex items-center gap-2 mb-6 overflow-x-auto scrollbar-none -mx-1 px-1">
+          {/* Type tabs */}
+          {ENTITY_TYPE_FILTERS.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => { setType(f.value); window.scrollTo({ top: 0 }); }}
+              className={cn(
+                "px-3 py-1.5 rounded-[var(--btn-r)] text-sm font-display font-semibold whitespace-nowrap transition-all border border-transparent cursor-pointer shrink-0",
+                type === f.value
+                  ? "bg-brand-m text-brand"
+                  : "text-fg-2 hover:text-fg hover:bg-surface",
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+
+          {/* Divider */}
+          <div className="w-px h-5 bg-border-s mx-1 shrink-0" />
+
+          {/* Sector dropdown (custom, styled) */}
+          <div className="shrink-0">
+            <SectorDropdown value={sector} onChange={setSector} options={SECTOR_LIST} />
+          </div>
+
+          {/* Raising toggle */}
+          <button
+            onClick={() => setRaising(!raising)}
+            role="switch"
+            aria-checked={raising}
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 rounded-[var(--btn-r)] border text-sm font-display font-semibold cursor-pointer transition-all duration-[200ms] whitespace-nowrap shrink-0",
+              raising
+                ? "border-transparent bg-brand-m text-brand"
+                : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l",
+            )}
+          >
+            <span
+              className={cn(
+                "relative inline-block w-8 h-[18px] rounded-full transition-colors duration-200 shrink-0",
+                raising ? "bg-brand" : "bg-border",
+              )}
+            >
+              <span
+                className={cn(
+                  "absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-[var(--white)] shadow-sm transition-transform duration-200",
+                  raising ? "translate-x-[14px]" : "translate-x-0",
+                )}
+              />
+            </span>
+            Actively Raising
           </button>
 
-          {type !== "all" && (
-            <span className="flex items-center gap-1.5 text-xs font-medium text-brand bg-brand-m px-2.5 py-1 rounded-[var(--btn-r)]">
-              {ENTITY_TYPE_LABELS[type as keyof typeof ENTITY_TYPE_LABELS]}
-              <button onClick={() => setType("all")} className="text-brand hover:text-brand-h cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
-            </span>
+          {hasFilters && (
+            <button
+              onClick={clearAll}
+              className="text-xs font-display font-semibold text-fg-3 hover:text-brand cursor-pointer bg-transparent border-none px-2 whitespace-nowrap shrink-0"
+            >
+              Clear all
+            </button>
           )}
-          {sector && (
-            <span className="flex items-center gap-1.5 text-xs font-medium text-brand bg-brand-m px-2.5 py-1 rounded-[var(--btn-r)]">
-              {sector}
-              <button onClick={() => setSector(null)} className="text-brand hover:text-brand-h cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
-            </span>
-          )}
-          {raising && (
-            <span className="flex items-center gap-1.5 text-xs font-medium text-signal-h bg-signal-m px-2.5 py-1 rounded-[var(--btn-r)]">
-              <span className="w-1.5 h-1.5 rounded-full bg-signal" />
-              Actively Raising
-              <button onClick={() => setRaising(false)} className="text-signal-h hover:text-signal cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
-            </span>
-          )}
-        </div>
 
-        <div className="flex items-center gap-3">
-          {/* Search */}
-          <div className="relative w-[280px] max-md:w-full">
+          {/* Spacer pushes search + count to the right */}
+          <div className="flex-1" />
+
+          <div className="relative w-[240px] shrink-0 max-md:w-[180px]">
             <SearchIcon />
             <input
               type="text"
               placeholder="Search by name, ticker..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="input pl-9"
+              className="input !pl-9"
             />
           </div>
-          <span className="text-xs text-fg-3 font-mono whitespace-nowrap">{total} results</span>
+          <span className="text-xs text-fg-3 font-mono whitespace-nowrap shrink-0">{total} results</span>
         </div>
-      </div>
+      )}
 
       {/* Content */}
       {filtered.length === 0 ? (
@@ -403,6 +638,24 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
           })}
         </div>
       )}
+
+      {/* Floating variant switcher (bottom-center) */}
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 p-1 rounded-[var(--btn-r)] border border-border bg-[var(--white)] shadow-lg">
+        {LAYOUT_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => setLayout(opt.value)}
+            className={cn(
+              "px-3 py-1.5 rounded-[var(--btn-r)] text-xs font-display font-semibold cursor-pointer transition-all duration-[200ms] border-none",
+              layout === opt.value
+                ? "bg-brand text-white"
+                : "bg-transparent text-fg-2 hover:text-brand",
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- **Entity profile** (`/directory/[slug]`): floating bottom-center switcher with three header variants — Crunchbase (default), V2 (CTAs in sidebar), V3 (editorial). V1 also gets a sticky compact bar that slides in once the full header scrolls past via IntersectionObserver — no layout shift.
- **Directory** (`/directory`): V1 (drawer) + V2 (inline filters) toggle. V2 uses Market-Feed-style type tabs, a custom portal-positioned sector dropdown (escapes overflow clip), and a brand-purple raising toggle. Active states drop their stroke for a cleaner pill read.
- **Entity card**: muted insights-style sector tag, brand-purple Raising pill with pulsing dot. Stats row reserves a fixed height so cards with and without ticker/price line up in the grid.

## Test plan
- [ ] `/directory` — toggle V1 ↔ V2 via floating switcher; verify drawer disappears in V2 and inline filters appear in one row.
- [ ] V2 sector dropdown opens, scrolls if overflowing, click-outside + Escape close it.
- [ ] V2 raising toggle: ball animates, brand-purple track + tinted bg + no stroke when active.
- [ ] Entity cards: with/without ticker line up vertically; Raising pill is brand purple.
- [ ] `/directory/khan-bank` — V1 sidebar on the left, V2 sidebar right with CTA stack on top, V3 editorial layout. Scroll V1 → compact sticky bar slides in. Scroll up → slides out.
- [ ] No regressions on Insights, Feed, or other pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)