### PR TITLE
muted card tags + feed/events polish

### DIFF
--- a/app/components/events/event-card.tsx
+++ b/app/components/events/event-card.tsx
@@ -162,20 +162,11 @@ function StatusBadge({
   status: { label: string; tone: "signal" | "pos" | "neg" | "fg" };
   size?: "xs" | "sm";
 }) {
-  const toneClass =
-    status.tone === "signal"
-      ? "bg-[var(--signal-m)] text-[color:var(--signal-h)]"
-      : status.tone === "pos"
-      ? "bg-[var(--pos-m)] text-[color:var(--pos-t)]"
-      : status.tone === "neg"
-      ? "bg-[var(--neg-m)] text-[color:var(--neg-t)]"
-      : "bg-surface text-fg-2";
   return (
     <span
       className={cn(
-        "inline-flex items-center font-mono uppercase font-semibold tracking-badge rounded-[var(--btn-r)]",
-        toneClass,
-        size === "xs" ? "text-[9px] px-1.5 py-0.5" : "text-[10px] px-2 py-0.5"
+        "inline-flex items-center font-body font-medium rounded-[var(--btn-r)] bg-surface text-fg-2",
+        size === "xs" ? "text-[10px] px-1.5 py-0.5" : "text-[11px] px-2 py-0.5",
       )}
     >
       {status.label}

--- a/app/components/feed/news-item-card.tsx
+++ b/app/components/feed/news-item-card.tsx
@@ -5,7 +5,6 @@ import {
   NEWS_CATEGORY_COLORS,
   NEWS_CATEGORY_LABELS,
 } from "@/app/lib/mock-data";
-import { cn } from "@/app/lib/cn";
 
 interface NewsItemCardProps {
   item: MockNewsItem;
@@ -132,7 +131,7 @@ export function NewsItemCard({
               <Link
                 key={e.slug}
                 href={`/directory/${e.slug}`}
-                className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-brand-m text-brand no-underline hover:bg-brand hover:text-white transition-colors"
+                className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2 no-underline hover:bg-brand-m hover:text-brand transition-colors"
               >
                 {e.ticker ?? e.name}
               </Link>
@@ -175,8 +174,7 @@ function CategoryDot({
 
 function BreakingBadge() {
   return (
-    <span className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-badge font-bold text-[color:var(--neg-t)] bg-[var(--neg-m)] px-1.5 py-0.5 rounded-[var(--btn-r)]">
-      <span className="w-1 h-1 rounded-full bg-[color:var(--neg)] animate-pulse" />
+    <span className="inline-flex items-center font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2">
       Breaking
     </span>
   );
@@ -185,10 +183,7 @@ function BreakingBadge() {
 function LowConfidenceBadge() {
   return (
     <span
-      className={cn(
-        "inline-flex items-center font-mono text-[10px] uppercase tracking-badge font-semibold",
-        "text-fg-3 border border-border bg-[var(--surface-down)] px-1.5 py-0.5 rounded-[var(--btn-r)]"
-      )}
+      className="inline-flex items-center font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2"
       title="Low-confidence AI tagging — pending analyst review"
     >
       Unverified

--- a/app/feed/feed-stream.tsx
+++ b/app/feed/feed-stream.tsx
@@ -81,10 +81,10 @@ export function FeedStream({ items }: FeedStreamProps) {
                 key={c.value}
                 onClick={() => setCategory(c.value)}
                 className={cn(
-                  "px-3 py-1.5 rounded-[var(--btn-r)] text-sm font-display font-semibold whitespace-nowrap transition-all border cursor-pointer",
+                  "px-3 py-1.5 rounded-[var(--btn-r)] text-sm font-display font-semibold whitespace-nowrap transition-all border border-transparent cursor-pointer",
                   category === c.value
-                    ? "border-brand bg-brand-m text-brand"
-                    : "border-transparent text-fg-2 hover:text-fg hover:bg-surface"
+                    ? "bg-brand-m text-brand"
+                    : "text-fg-2 hover:text-fg hover:bg-surface"
                 )}
               >
                 {c.label}
@@ -128,7 +128,7 @@ export function FeedStream({ items }: FeedStreamProps) {
                     className="sticky z-20 -mx-2 px-2 py-2 backdrop-blur-md bg-[var(--header-blur)] border-b border-border-s flex items-center gap-3 mb-3"
                     style={{ top: "var(--header-h)" }}
                   >
-                    <h2 className="font-display font-extrabold text-sm uppercase tracking-[0.08em] text-fg-2">
+                    <h2 className="font-display font-extrabold text-sm tracking-tight text-fg-2">
                       {label}
                     </h2>
                     <div className="flex-1 h-px bg-border-s" />


### PR DESCRIPTION
## Summary
- **Feed cards**: entity refs (KHAN/GLMT/etc.), Breaking, and Unverified pills are now muted (`bg-surface text-fg-2`) — were brand-tinted, red-tinted, and outlined respectively.
- **Event cards**: status pill drops its signal/pos/neg tone coloring; all states render as muted pills, matching the directory entity-card sector tag.
- **Feed inline filters**: active chip drops the brand-purple stroke, matching the directory V2 treatment.
- **Day-group headers** ("Today", "This week", "Earlier"): natural casing — `uppercase` class removed from the shared h2.

## Test plan
- [ ] `/feed` — every pill on the news cards reads muted gray (entity refs, Breaking, Unverified).
- [ ] Active category chip on /feed has no brand border, just the tinted fill.
- [ ] Day-group headers "Today" / "This week" / "Earlier" render mixed case.
- [ ] `/events` — status pills (Upcoming / Registration Open / Sold Out / Past) all muted.
- [ ] No regressions on directory entity cards or insights cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)