### PR TITLE
entity profile: AI-Sourced fall-back tier

### DIFF
--- a/app/components/entity/ai-sourced-profile.tsx
+++ b/app/components/entity/ai-sourced-profile.tsx
@@ -1,0 +1,231 @@
+import { Widget, WidgetHeader, WidgetBody } from "@/app/components/ui";
+import { EntityHeader } from "./entity-header";
+import { NewsWidget } from "./news-widget";
+import type {
+  AIConfidence,
+  AISourceCitation,
+  MockEntity,
+} from "@/app/lib/mock-data";
+import { ENTITY_TYPE_LABELS } from "@/app/lib/mock-data";
+
+/* ═══════════════════════════════════════════════════════════
+   AI-Sourced Entity Profile (fall-back tier)
+   Sections: header, AI disclaimer, overview, news, citations.
+   Single sidebar CTA: claim this profile.
+   Same MockEntity shape as premium — most fields null.
+   ═══════════════════════════════════════════════════════════ */
+
+const CONFIDENCE_STYLE: Record<AIConfidence, string> = {
+  high: "bg-pos-m text-pos",
+  medium: "bg-signal-m text-signal-h",
+  low: "bg-neg-m text-neg-t",
+};
+
+function ConfidenceDot({ level }: { level: AIConfidence }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-[var(--badge-r)] text-[10px] font-mono font-semibold uppercase tracking-wider ${CONFIDENCE_STYLE[level]}`}
+    >
+      {level}
+    </span>
+  );
+}
+
+interface AISourcedProfileProps {
+  entity: MockEntity;
+}
+
+export function AISourcedProfile({ entity }: AISourcedProfileProps) {
+  const initials = entity.name
+    .split(/[\s-]+/)
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+
+  const typeLabel = ENTITY_TYPE_LABELS[entity.type];
+  const ai = entity.aiMeta;
+
+  /* News pipeline still runs on AI-Sourced profiles — this is the free strength */
+  const news = [
+    {
+      id: "n1",
+      title: `Mongolia ${entity.sector.toLowerCase()} sector outlook for Q2 2026`,
+      source: "Mining Weekly",
+      date: "Apr 28, 2026",
+    },
+    {
+      id: "n2",
+      title: `${entity.name} reportedly named in MRPAM license disclosure`,
+      source: "UB Post",
+      date: "Apr 14, 2026",
+    },
+    {
+      id: "n3",
+      title: `Foreign investor interest in Mongolia's ${entity.sector} sector grows`,
+      source: "Bloomberg",
+      date: "Apr 02, 2026",
+    },
+  ];
+
+  /* Sort citations: low confidence first (analyst attention) */
+  const sortedCitations: AISourceCitation[] = ai
+    ? [...ai.citations].sort((a, b) => {
+        const order: Record<AIConfidence, number> = { low: 0, medium: 1, high: 2 };
+        return order[a.confidence] - order[b.confidence];
+      })
+    : [];
+
+  return (
+    <div className="max-w-[var(--content-max)] mx-auto px-6 w-full">
+      {/* Header */}
+      <div className="profile-header pt-6">
+        <EntityHeader
+          name={entity.name}
+          initials={initials}
+          ticker={entity.ticker}
+          exchange={entity.exchange ?? (entity.ticker ? "MSE" : undefined)}
+          type={typeLabel}
+          typeVariant={entity.type === "project" ? "project" : "company"}
+          sector={entity.sector}
+          dataSource="AI-Sourced"
+          website={entity.website}
+          location={entity.location}
+          yearEstablished={entity.yearEstablished}
+          socialLinks={entity.socialLinks}
+        />
+      </div>
+
+      {/* AI disclaimer band */}
+      <div className="rounded-[var(--card-r)] border border-signal/30 bg-signal-m px-4 py-3 mb-6 flex items-start gap-3">
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="text-signal-h shrink-0 mt-0.5"
+        >
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <div className="flex-1 min-w-0">
+          <div className="font-display font-semibold text-sm text-fg leading-snug">
+            This profile is AI-sourced and has not been verified by CMM analysts.
+          </div>
+          <div className="text-xs text-fg-2 mt-1 leading-relaxed">
+            Data assembled from public registries, filings, and web sources by an automated
+            pipeline. Treat as a starting point, not a research-grade profile.
+            {ai && (
+              <>
+                {" "}
+                Last refreshed{" "}
+                <span className="font-mono">
+                  {new Date(ai.lastCrawled).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                </span>
+                .
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-[1fr_340px] gap-12 pb-20 items-start max-lg:grid-cols-1 max-lg:gap-6">
+        {/* ── Main column ── */}
+        <div className="flex flex-col gap-5 min-w-0">
+          {/* AI-generated description */}
+          {entity.description && (
+            <Widget>
+              <WidgetHeader
+                title="Overview"
+                action={
+                  <span className="font-mono text-[10px] uppercase tracking-wider text-fg-3">
+                    AI-generated
+                  </span>
+                }
+              />
+              <WidgetBody>
+                <p className="text-sm text-fg-2 leading-relaxed m-0">
+                  {entity.description}
+                </p>
+              </WidgetBody>
+            </Widget>
+          )}
+
+          {/* Recent News (free strength of the AI pipeline) */}
+          <NewsWidget items={news} />
+
+          {/* AI source citations */}
+          {ai && (
+            <Widget>
+              <WidgetHeader
+                title="AI Source Citations"
+                action={
+                  <span className="font-mono text-[10px] uppercase tracking-wider text-fg-3">
+                    {sortedCitations.length} fields
+                  </span>
+                }
+              />
+              <WidgetBody>
+                <p className="text-xs text-fg-3 leading-relaxed mt-0 mb-3">
+                  Field-level provenance for analyst review. Low-confidence rows shown first.
+                </p>
+                <div className="flex flex-col">
+                  {sortedCitations.map((c) => (
+                    <div
+                      key={c.field}
+                      className="flex items-center justify-between gap-3 py-2 border-b border-border-s last:border-b-0 text-sm"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="font-mono text-xs text-fg-2 w-32 shrink-0 truncate">
+                          {c.field}
+                        </span>
+                        <span className="text-xs text-fg-3 truncate">{c.source}</span>
+                      </div>
+                      <ConfidenceDot level={c.confidence} />
+                    </div>
+                  ))}
+                </div>
+                {ai.pipelineRun && (
+                  <div className="mt-3 pt-3 border-t border-border-s text-[11px] font-mono text-fg-3">
+                    Run: {ai.pipelineRun}
+                  </div>
+                )}
+              </WidgetBody>
+            </Widget>
+          )}
+        </div>
+
+        {/* ── Sticky sidebar (claim CTA only) ── */}
+        <aside className="lg:sticky lg:top-[80px] flex flex-col gap-5">
+          <div
+            className="rounded-[var(--card-r)] border-2 border-brand p-5 flex flex-col gap-3"
+            style={{ background: "linear-gradient(135deg, var(--brand-m), var(--surface-el))" }}
+          >
+            <div className="font-display font-extrabold text-base text-fg leading-tight">
+              Are you {entity.name}?
+            </div>
+            <p className="text-xs text-fg-2 leading-relaxed m-0">
+              Claim this profile to verify your information, upload official assets, and reach
+              Mongolia&apos;s capital markets community.
+            </p>
+            <button className="btn btn-primary text-sm w-full">Claim this profile</button>
+            <div className="text-[11px] text-fg-3 leading-snug">
+              Verification typically takes 2-3 business days.
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/app/components/entity/index.ts
+++ b/app/components/entity/index.ts
@@ -17,3 +17,4 @@ export { BoardMembersWidget } from "./board-members-widget";
 export { ParentGroupCard } from "./parent-group-card";
 export { ExecutiveOrgChart } from "./executive-org-chart";
 export { EntityCoverageWidget } from "./entity-coverage-widget";
+export { AISourcedProfile } from "./ai-sourced-profile";

--- a/app/components/entity/profile-badge-widget.tsx
+++ b/app/components/entity/profile-badge-widget.tsx
@@ -7,6 +7,15 @@ interface ProfileBadgeWidgetProps {
 }
 
 const BADGE_STYLES: Record<DataSource, { label: string; classes: string; icon: React.ReactNode }> = {
+  "CMM Curated": {
+    label: "CMM Curated",
+    classes: "bg-pos-m text-pos",
+    icon: (
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2L9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2z" />
+      </svg>
+    ),
+  },
   "CMM Verified": {
     label: "CMM Verified",
     classes: "bg-pos-m text-pos",
@@ -14,6 +23,17 @@ const BADGE_STYLES: Record<DataSource, { label: string; classes: string; icon: R
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
         <path d="m9 11 3 3L22 4" />
         <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      </svg>
+    ),
+  },
+  "AI-Sourced": {
+    label: "AI-Sourced · Unverified",
+    classes: "bg-signal-m text-signal-h",
+    icon: (
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" />
+        <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
       </svg>
     ),
   },

--- a/app/directory/[slug]/page.tsx
+++ b/app/directory/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
   ParentGroupCard,
   ExecutiveOrgChart,
   EntityCoverageWidget,
+  AISourcedProfile,
 } from "@/app/components/entity";
 import { ArticleSidebar } from "@/app/components/content/article-sidebar";
 import { BlockerLabel } from "@/app/components/ui/blocker-label";
@@ -110,6 +111,11 @@ export default async function EntityProfilePage({ params }: PageProps) {
   const { slug } = await params;
   const entity = MOCK_ENTITIES.find((e) => e.slug === slug);
   if (!entity) notFound();
+
+  /* AI-Sourced profiles render the thin fall-back layout */
+  if (entity.dataSource === "AI-Sourced") {
+    return <AISourcedProfile entity={entity} />;
+  }
 
   const initials = entity.name
     .split(/[\s-]+/)

--- a/app/lib/mock-data.ts
+++ b/app/lib/mock-data.ts
@@ -45,7 +45,25 @@ export const SECTOR_LIST = [
 
 /* ── Rich entity spec (from Entity Fields Master, Apr 23) ── */
 
-export type DataSource = "AI-Generated" | "CMM Verified" | "Company Submitted";
+export type DataSource = "AI-Sourced" | "AI-Generated" | "CMM Verified" | "CMM Curated" | "Company Submitted";
+
+export type AIConfidence = "high" | "medium" | "low";
+
+export interface AISourceCitation {
+  field: string;
+  source: string;
+  url?: string;
+  confidence: AIConfidence;
+}
+
+export interface AISourceMeta {
+  /** ISO date the AI pipeline last refreshed this profile */
+  lastCrawled: string;
+  /** Field-level provenance for analyst spot-check */
+  citations: AISourceCitation[];
+  /** Optional model + run ID for traceability */
+  pipelineRun?: string;
+}
 export type ListingLocation = "LOCAL" | "FOREIGN";
 export type ProjectStage = "Exploration" | "Feasibility" | "Construction" | "Operating" | "Expansion";
 
@@ -198,6 +216,9 @@ export interface MockEntity {
   sustainabilityDocs?: Download[];
   investmentTeasers?: Download[];
   operationalDocs?: Download[];
+
+  /* AI-Sourced metadata (only present when dataSource === "AI-Sourced") */
+  aiMeta?: AISourceMeta;
 }
 
 export const MOCK_ARTICLES: MockArticle[] = [
@@ -982,6 +1003,88 @@ export const MOCK_ENTITIES: MockEntity[] = [
     price: 1240,
     change: 15,
     changePercent: 1.22,
+  },
+
+  /* ── AI-Sourced profiles (fall-back tier, sparse data, claim CTAs) ── */
+  {
+    slug: "khar-tolgoi-mining",
+    name: "Khar Tolgoi Mining JSC",
+    ticker: "KHTM",
+    sector: "Mining & Resources",
+    type: "public_company",
+    description:
+      "Khar Tolgoi Mining JSC is an MSE-listed company referenced in mineral processing filings, with reported activity in fluorspar and base metals. Public disclosures suggest small-cap operations in the Selenge aimag. This profile is auto-generated from open sources and has not been verified by CMM analysts. Financial data, ownership, and corporate filings have not been reviewed.",
+    listingLocation: "LOCAL",
+    exchange: "MSE",
+    website: "https://khartolgoi.mn",
+    location: "Selenge, Mongolia",
+    yearEstablished: 2007,
+    dataSource: "AI-Sourced",
+    aiMeta: {
+      lastCrawled: "2026-05-05",
+      pipelineRun: "ai-pipeline-2026-05-05-r92",
+      citations: [
+        { field: "name", source: "MSE listed companies registry", confidence: "high" },
+        { field: "ticker", source: "MSE listed companies registry", confidence: "high" },
+        { field: "exchange", source: "MSE listed companies registry", confidence: "high" },
+        { field: "sector", source: "MSE sector classification", confidence: "high" },
+        { field: "yearEstablished", source: "State Registration Office record", confidence: "medium" },
+        { field: "location", source: "MRPAM license geo-data", confidence: "medium" },
+        { field: "website", source: "Domain WHOIS + MSE filings", confidence: "medium" },
+        { field: "description", source: "Synthesized from MSE filings + 3 news mentions", confidence: "low" },
+      ],
+    },
+  },
+  {
+    slug: "bayan-airag-exploration",
+    name: "Bayan-Airag Exploration LLC",
+    sector: "Mining & Resources",
+    type: "private_company",
+    description:
+      "Bayan-Airag Exploration LLC is a Mongolia-registered mineral exploration company reportedly holding licenses in the Govi-Altai region. Public records suggest a focus on copper-gold porphyry targets. This profile is auto-generated from open sources and has not been verified by CMM analysts.",
+    website: "https://bayan-airag.mn",
+    location: "Govi-Altai, Mongolia",
+    yearEstablished: 2018,
+    dataSource: "AI-Sourced",
+    aiMeta: {
+      lastCrawled: "2026-05-04",
+      pipelineRun: "ai-pipeline-2026-05-04-r91",
+      citations: [
+        { field: "name", source: "Mongolia State Registry", confidence: "high" },
+        { field: "sector", source: "Inferred from mineral license filings (MRPAM)", confidence: "high" },
+        { field: "yearEstablished", source: "State Registration Office record", confidence: "high" },
+        { field: "location", source: "MRPAM license geo-data", confidence: "medium" },
+        { field: "website", source: "Web crawl, domain WHOIS", confidence: "medium" },
+        { field: "description", source: "Generated from filings + sector context", confidence: "low" },
+      ],
+    },
+  },
+  {
+    slug: "digipay-mongolia",
+    name: "DigiPay Mongolia LLC",
+    sector: "Technology",
+    type: "private_company",
+    description:
+      "DigiPay Mongolia LLC appears to operate a mobile payments and merchant settlement platform serving small businesses in Ulaanbaatar. Press mentions reference partnerships with two domestic banks. Headcount and financials are not publicly disclosed. This profile is auto-generated from open sources.",
+    website: "https://digipay.mn",
+    location: "Ulaanbaatar, Mongolia",
+    yearEstablished: 2021,
+    dataSource: "AI-Sourced",
+    socialLinks: {
+      facebook: "https://facebook.com/digipaymn",
+    },
+    aiMeta: {
+      lastCrawled: "2026-05-06",
+      pipelineRun: "ai-pipeline-2026-05-06-r93",
+      citations: [
+        { field: "name", source: "Mongolia State Registry", confidence: "high" },
+        { field: "sector", source: "Inferred from press coverage + website meta", confidence: "high" },
+        { field: "website", source: "Domain WHOIS + Google search", confidence: "high" },
+        { field: "yearEstablished", source: "State Registration Office record", confidence: "medium" },
+        { field: "location", source: "Website footer + LinkedIn", confidence: "medium" },
+        { field: "description", source: "Synthesized from 4 news mentions", confidence: "low" },
+      ],
+    },
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds a thin AI-Sourced profile variant for entities the AI pipeline discovers from open sources but no analyst has reviewed. Designed to be **easy to build, easy to review, and visibly different from CMM Verified profiles** so it doesn't devalue the premium tier we sell.

The design is the alternative to filling 60+ fields per entity. We give investors *something* (name, sector, AI-generated description, news), make the unverified status loud, and use the empty space as a sales surface (claim CTA + investor-side verification request).

## What's in the profile

- **Header** — name, sector, type, location, year (and ticker/exchange for public companies); high-confidence AI fields only
- **AI disclaimer band** — amber notice that the profile is unverified, with last-crawled date
- **Overview** — AI-generated description with visible "AI-generated" tag in the widget header
- **Market News** — surfaces the existing news pipeline (the AI side's free strength)
- **AI Source Citations** — field-level provenance sorted low-confidence first; turns analyst review into a 3-minute spot check rather than 60-field validation
- **Sidebar** — single "Claim this profile" CTA (company-side sales hook)

## What's deliberately excluded (the moat)

No financials, ownership, key people, deal insights, or downloads. These remain CMM Verified / Curated only — they're the deepest analyst labor and the highest-trust signal investors actually pay for.

## Implementation

- Same `MockEntity` shape as premium — most fields just null. Upgrade path is filling rows, not migrating data.
- New `AISourceMeta` / `AISourceCitation` types carry per-field source URL + confidence (high/medium/low).
- `dataSource: "AI-Sourced"` on the entity branches `/directory/[slug]/page.tsx` to render the new component.
- New badge tier in `ProfileBadgeWidget` ("AI-Sourced · Unverified", amber). `CMM Curated` also added to the type union for the full 3-tier roadmap (per the badge decision proposal).

## Files

- `app/components/entity/ai-sourced-profile.tsx` (new, ~220 lines)
- `app/components/entity/profile-badge-widget.tsx` — added AI-Sourced + CMM Curated badges
- `app/components/entity/index.ts` — export
- `app/lib/mock-data.ts` — `DataSource` union update, new types, 3 mock entities
- `app/directory/[slug]/page.tsx` — early-return branch on `dataSource === "AI-Sourced"`

## Live examples (run locally)

- `/directory/khar-tolgoi-mining` — Public Company (KHTM, MSE-listed; ticker shown but no price/market data)
- `/directory/bayan-airag-exploration` — Private Company (mining exploration)
- `/directory/digipay-mongolia` — Private Company (fintech)

Compare against `/directory/golomt-bank` (CMM Verified) to see the gap.

## Test plan

- [ ] All three AI-Sourced slugs render at HTTP 200
- [ ] Premium profiles (e.g. `/directory/golomt-bank`) still render unchanged
- [ ] `AI-Sourced · Unverified` badge appears in the header meta row
- [ ] AI Source Citations widget sorts low-confidence rows first
- [ ] Sidebar shows only the "Claim this profile" card on AI-Sourced; original sidebar (TOC / RequestConnection / Downloads) on premium
- [ ] No regressions on the public-company / private-company / project / service-provider premium layouts
- [ ] Mobile breakpoints (<lg): sidebar stacks below main column

## Open decisions (not blocking this PR)

The badge memo's 3-tier proposal (AI-Sourced / CMM Verified / CMM Curated) is still pending Zoloo + Namkhai sign-off. This PR ships the AI-Sourced tier as a UI-side mockup; the DB CHECK constraint shouldn't be updated until leadership confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)