### PR TITLE
wire BFF: clerk auto-token, directory backend filters, real registration

### DIFF
--- a/app/components/directory/entity-card.tsx
+++ b/app/components/directory/entity-card.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { cn } from "@/app/lib/cn";
-import type { MockEntity } from "@/app/lib/mock-data";
+import { SECTOR_SLUG_TO_LABEL, type MockEntity } from "@/app/lib/mock-data";
 
 /* ── EntityCard ───────────────────────────── */
 
@@ -72,7 +72,7 @@ export function EntityCard({ entity }: { entity: MockEntity }) {
       {/* Tags — muted sector pill + highlighted raising pill (type comes from section context) */}
       <div className="flex gap-1.5 mt-2.5 flex-wrap">
         <span className="font-body font-medium text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-surface text-fg-2">
-          {entity.sector}
+          {SECTOR_SLUG_TO_LABEL[entity.sector] ?? entity.sector}
         </span>
         {entity.isRaising && (
           <span className="inline-flex items-center gap-1.5 font-body font-semibold text-[11px] py-0.5 px-2 rounded-[var(--btn-r)] bg-brand text-[var(--brand-t)]">

--- a/app/components/events/register-action.ts
+++ b/app/components/events/register-action.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { ApiError, apiPost, path } from "@/app/lib/api";
+
+export interface RegisterActionState {
+  status: "idle" | "success" | "error";
+  message?: string;
+}
+
+export async function registerForEventAction(
+  slug: string,
+  _prev: RegisterActionState,
+  formData: FormData,
+): Promise<RegisterActionState> {
+  const name = String(formData.get("name") ?? "").trim();
+  const email = String(formData.get("email") ?? "").trim();
+  const company = String(formData.get("company") ?? "").trim();
+  const title = String(formData.get("title") ?? "").trim();
+  const notes = String(formData.get("notes") ?? "").trim();
+
+  if (!name || !email) {
+    return { status: "error", message: "Name and email are required." };
+  }
+
+  try {
+    await apiPost(path("/api/events/{slug}/register", { slug }), {
+      body: {
+        name,
+        email,
+        company: company || undefined,
+        title: title || undefined,
+        notes: notes || undefined,
+      },
+    });
+    return { status: "success" };
+  } catch (err) {
+    if (err instanceof ApiError) {
+      const payload = err.payload as { message?: string | string[] } | null;
+      const msg = Array.isArray(payload?.message)
+        ? payload.message.join(", ")
+        : (payload?.message ?? `Registration failed (${err.status}).`);
+      return { status: "error", message: msg };
+    }
+    console.error("[event register] unexpected error:", err);
+    return {
+      status: "error",
+      message: "Something went wrong. Please try again in a moment.",
+    };
+  }
+}

--- a/app/components/events/registration-form.tsx
+++ b/app/components/events/registration-form.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useActionState, useState } from "react";
+import { useFormStatus } from "react-dom";
 import { cn } from "@/app/lib/cn";
+import {
+  registerForEventAction,
+  type RegisterActionState,
+} from "./register-action";
 
 interface RegistrationFormProps {
+  slug: string;
   eventTitle: string;
   ticketPrice?: string;
   registrationDeadline?: string;
@@ -14,25 +20,19 @@ const ATTENDANCE_TYPES = [
   { value: "virtual", label: "Virtual" },
 ];
 
+const INITIAL: RegisterActionState = { status: "idle" };
+
 export function RegistrationForm({
+  slug,
   eventTitle,
   ticketPrice,
   registrationDeadline,
 }: RegistrationFormProps) {
-  const [submitted, setSubmitted] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
+  const action = registerForEventAction.bind(null, slug);
+  const [state, formAction] = useActionState(action, INITIAL);
   const [attendance, setAttendance] = useState("in-person");
 
-  function handleSubmit(e: { preventDefault: () => void }) {
-    e.preventDefault();
-    setSubmitting(true);
-    setTimeout(() => {
-      setSubmitting(false);
-      setSubmitted(true);
-    }, 700);
-  }
-
-  if (submitted) {
+  if (state.status === "success") {
     return (
       <div className="card !p-6 flex flex-col gap-3">
         <div className="w-10 h-10 rounded-full bg-pos-m grid place-items-center">
@@ -53,7 +53,7 @@ export function RegistrationForm({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="card !p-6 flex flex-col gap-4">
+    <form action={formAction} className="card !p-6 flex flex-col gap-4">
       <div>
         <div className="font-display font-extrabold text-base mb-1">
           Reserve your spot
@@ -109,18 +109,31 @@ export function RegistrationForm({
         placeholder="Dietary restrictions, accessibility, or topics you'd want to discuss 1:1."
       />
 
-      <button
-        type="submit"
-        disabled={submitting}
-        className="btn btn-primary w-full justify-center"
-      >
-        {submitting ? "Submitting…" : "Complete Registration"}
-      </button>
+      {state.status === "error" && state.message && (
+        <div className="text-sm text-neg bg-neg-m px-3 py-2 rounded-[var(--btn-r)] leading-[1.4]">
+          {state.message}
+        </div>
+      )}
+
+      <SubmitButton />
 
       <p className="text-[11px] text-fg-3 leading-[1.5]">
         By registering you agree to CMM&apos;s code of conduct and event policies.
       </p>
     </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="btn btn-primary w-full justify-center"
+    >
+      {pending ? "Submitting…" : "Complete Registration"}
+    </button>
   );
 }
 

--- a/app/components/insights/insights-grid.tsx
+++ b/app/components/insights/insights-grid.tsx
@@ -143,7 +143,7 @@ function Hero({
           className="mt-4 font-bold tracking-[-0.02em] leading-[1.02] text-fg group-hover:text-brand transition-colors"
           style={{
             fontFamily: "var(--font-s)",
-            fontSize: "clamp(2.5rem, 5.5vw, 4.5rem)",
+            fontSize: "clamp(1.6rem, 3.52vw, 2.88rem)",
           }}
         >
           <span>{article.title}</span>

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -81,9 +81,17 @@ export function Header() {
           </button>
 
           {isLoaded && !isSignedIn && (
-            <Link href="/sign-in" className="btn btn-primary hidden sm:inline-flex">
-              Sign In
-            </Link>
+            <div className="hidden sm:flex items-center gap-1">
+              <Link
+                href="/sign-in"
+                className="px-3 h-[34px] inline-flex items-center font-display font-semibold text-sm text-fg hover:text-brand transition-colors no-underline"
+              >
+                Sign In
+              </Link>
+              <Link href="/sign-up" className="btn btn-primary">
+                Get started
+              </Link>
+            </div>
           )}
           {isLoaded && isSignedIn && (
             <div className="hidden sm:flex items-center">
@@ -118,12 +126,14 @@ export function Header() {
               );
             })}
             {isLoaded && !isSignedIn && (
-              <Link
-                href="/sign-in"
-                className="btn btn-primary mt-2 sm:hidden text-center"
-              >
-                Sign In
-              </Link>
+              <div className="mt-2 sm:hidden flex flex-col gap-2">
+                <Link href="/sign-in" className="btn btn-secondary text-center">
+                  Sign In
+                </Link>
+                <Link href="/sign-up" className="btn btn-primary text-center">
+                  Get started
+                </Link>
+              </div>
             )}
             {isLoaded && isSignedIn && (
               <div className="mt-3 sm:hidden flex justify-center">

--- a/app/directory/[slug]/profile-variants.tsx
+++ b/app/directory/[slug]/profile-variants.tsx
@@ -4,14 +4,6 @@ import { useEffect, useRef, useState, type ComponentProps, type ReactNode } from
 import { EntityHeader } from "@/app/components/entity";
 import { cn } from "@/app/lib/cn";
 
-type Variant = "v1" | "v2" | "v3";
-
-const VARIANTS: { value: Variant; label: string }[] = [
-  { value: "v1", label: "Crunchbase" },
-  { value: "v2", label: "V2 — Sidebar CTAs" },
-  { value: "v3", label: "V3 — Editorial" },
-];
-
 interface ProfileVariantsProps {
   headerProps: Omit<ComponentProps<typeof EntityHeader>, "variant">;
   mainContent: ReactNode;
@@ -23,15 +15,10 @@ export function ProfileVariants({
   mainContent,
   sidebarContent,
 }: ProfileVariantsProps) {
-  const [variant, setVariant] = useState<Variant>("v1");
   const [showCompactBar, setShowCompactBar] = useState(false);
   const fullHeaderRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (variant !== "v1") {
-      setShowCompactBar(false);
-      return;
-    }
     const el = fullHeaderRef.current;
     if (!el) return;
     const observer = new IntersectionObserver(
@@ -40,85 +27,36 @@ export function ProfileVariants({
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [variant]);
+  }, []);
 
   return (
     <>
-      {/* Sticky compact bar (V1 only) — slides in once the full header scrolls out of view */}
-      {variant === "v1" && (
-        <div
-          className={cn(
-            "fixed top-[var(--header-h)] left-0 right-0 z-30 bg-[var(--bg)] border-b border-border-s transition-transform duration-200 ease-out",
-            showCompactBar ? "translate-y-0" : "-translate-y-full",
-          )}
-        >
-          <div className="max-w-[var(--content-max)] mx-auto px-6 w-full py-2">
-            <EntityHeader {...headerProps} variant="v1" compact />
-          </div>
-        </div>
-      )}
-
-      <div className="max-w-[var(--content-max)] mx-auto px-6 w-full py-0">
-        <div ref={fullHeaderRef} className="pt-6">
-          <EntityHeader {...headerProps} variant={variant} />
-        </div>
-
-        <div
-          className={cn(
-            "grid gap-5 pb-20 items-start max-lg:grid-cols-1",
-            variant === "v1"
-              ? "grid-cols-[340px_1fr]"
-              : "grid-cols-[1fr_340px]",
-          )}
-        >
-          <div
-            className={cn(
-              "flex flex-col gap-5 min-w-0",
-              variant === "v1" && "lg:order-2",
-            )}
-          >
-            {mainContent}
-          </div>
-
-          <aside
-            className={cn(
-              "lg:sticky lg:top-[80px] flex flex-col gap-5 max-lg:grid max-lg:grid-cols-2 max-md:grid-cols-1",
-              variant === "v1" && "lg:order-1",
-            )}
-          >
-            {(variant === "v2" || variant === "v3") && (
-              <div className="widget">
-                <div className="widget-body flex flex-col gap-2">
-                  <button className="btn btn-secondary text-sm w-full">
-                    Add to Watchlist
-                  </button>
-                  <button className="btn btn-signal text-sm w-full">
-                    Request Connection
-                  </button>
-                </div>
-              </div>
-            )}
-            {sidebarContent}
-          </aside>
+      {/* Sticky compact bar — slides in once the full header scrolls out of view */}
+      <div
+        className={cn(
+          "fixed top-[var(--header-h)] left-0 right-0 z-30 bg-[var(--bg)] border-b border-border-s transition-transform duration-200 ease-out",
+          showCompactBar ? "translate-y-0" : "-translate-y-full",
+        )}
+      >
+        <div className="max-w-[var(--content-max)] mx-auto px-6 w-full py-2">
+          <EntityHeader {...headerProps} variant="v1" compact />
         </div>
       </div>
 
-      {/* Floating variant switcher (bottom-center) */}
-      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 p-1 rounded-[var(--btn-r)] border border-border bg-[var(--white)] shadow-lg">
-        {VARIANTS.map((v) => (
-          <button
-            key={v.value}
-            onClick={() => setVariant(v.value)}
-            className={cn(
-              "px-3 py-1.5 rounded-[var(--btn-r)] text-xs font-display font-semibold cursor-pointer transition-all duration-[200ms] border-none",
-              variant === v.value
-                ? "bg-brand text-white"
-                : "bg-transparent text-fg-2 hover:text-brand",
-            )}
-          >
-            {v.label}
-          </button>
-        ))}
+      <div className="max-w-[var(--content-max)] mx-auto px-6 w-full py-0">
+        <div ref={fullHeaderRef} className="pt-6">
+          <EntityHeader {...headerProps} variant="v1" />
+        </div>
+
+        <div className="grid gap-5 pb-20 items-start max-lg:grid-cols-1 grid-cols-[340px_1fr]">
+          <div className="flex flex-col gap-5 min-w-0 lg:order-2">
+            {mainContent}
+          </div>
+
+          <aside className="lg:sticky lg:top-[80px] flex flex-col gap-5 max-lg:grid max-lg:grid-cols-2 max-md:grid-cols-1 lg:order-1">
+            {sidebarContent}
+          </aside>
+        </div>
       </div>
     </>
   );

--- a/app/directory/directory-controls.tsx
+++ b/app/directory/directory-controls.tsx
@@ -1,201 +1,487 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { useCallback, useState, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { EntityCard } from "@/app/components/directory/entity-card";
 import { cn } from "@/app/lib/cn";
-import type { MockEntity } from "@/app/lib/mock-data";
-import { ENTITY_TYPE_FILTERS, ENTITY_TYPE_LABELS, SECTOR_LIST } from "@/app/lib/mock-data";
+import {
+  ENTITY_TYPE_FILTERS,
+  ENTITY_TYPE_LABELS,
+  SECTOR_OPTIONS,
+  SECTOR_SLUG_TO_LABEL,
+  type EntityType,
+  type MockEntity,
+} from "@/app/lib/mock-data";
 
-const TYPE_ORDER = [
+const TYPE_ORDER: { variant: EntityType; label: string }[] = [
   { variant: "public_company", label: "Public Companies" },
   { variant: "private_company", label: "Private Companies" },
   { variant: "project", label: "Projects" },
   { variant: "service_provider", label: "Service Providers" },
 ];
 
-const SECTION_PREVIEW = 8;
-
-/* ── URL param helpers ───────────────────── */
-
-function readParams() {
-  if (typeof window === "undefined") return {};
-  const p = new URLSearchParams(window.location.search);
-  return {
-    q: p.get("q") ?? "",
-    type: p.get("type") ?? "all",
-    sector: p.get("sector") ?? null,
-    raising: p.get("raising") === "1",
-  };
-}
-
-function writeParams(state: {
+interface FilterState {
   q: string;
   type: string;
   sector: string | null;
   raising: boolean;
-}) {
-  const p = new URLSearchParams();
-  if (state.q) p.set("q", state.q);
-  if (state.type !== "all") p.set("type", state.type);
-  if (state.sector) p.set("sector", state.sector);
-  if (state.raising) p.set("raising", "1");
-  const str = p.toString();
-  window.history.replaceState(null, "", str ? `?${str}` : window.location.pathname);
 }
 
-/* ── Sector dropdown ─────────────────────── */
+type SectionsMode = {
+  mode: "sections";
+  sections: Array<{ type: EntityType; items: MockEntity[]; total: number }>;
+  filters: FilterState;
+};
 
-function SectorDropdown({
-  value,
-  onChange,
-  options,
+type FilteredMode = {
+  mode: "filtered";
+  items: MockEntity[];
+  total: number;
+  page: number;
+  pageSize: number;
+  filters: FilterState;
+};
+
+type Props = SectionsMode | FilteredMode;
+
+export function DirectoryControls(props: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  const { filters } = props;
+  const [searchDraft, setSearchDraft] = useState(filters.q);
+
+  const navigate = useCallback(
+    (next: URLSearchParams) => {
+      const qs = next.toString();
+      startTransition(() => {
+        router.push(qs ? `${pathname}?${qs}` : pathname);
+      });
+    },
+    [pathname, router],
+  );
+
+  const updateFilter = useCallback(
+    (patch: Partial<FilterState>) => {
+      const next = new URLSearchParams(searchParams.toString());
+      const merged = { ...filters, ...patch };
+
+      if (merged.q) next.set("q", merged.q);
+      else next.delete("q");
+      if (merged.type !== "all") next.set("type", merged.type);
+      else next.delete("type");
+      if (merged.sector) next.set("sector", merged.sector);
+      else next.delete("sector");
+      if (merged.raising) next.set("raising", "1");
+      else next.delete("raising");
+      // Any filter change resets paging.
+      next.delete("page");
+
+      navigate(next);
+    },
+    [filters, navigate, searchParams],
+  );
+
+  const goToPage = useCallback(
+    (p: number) => {
+      const next = new URLSearchParams(searchParams.toString());
+      if (p <= 1) next.delete("page");
+      else next.set("page", String(p));
+      navigate(next);
+    },
+    [navigate, searchParams],
+  );
+
+  const submitSearch = useCallback(() => {
+    if (searchDraft.trim() === filters.q) return;
+    updateFilter({ q: searchDraft.trim() });
+  }, [searchDraft, filters.q, updateFilter]);
+
+  const clearAll = useCallback(() => {
+    setSearchDraft("");
+    startTransition(() => router.push(pathname));
+  }, [pathname, router]);
+
+  const hasFilters =
+    !!filters.q || filters.type !== "all" || !!filters.sector || filters.raising;
+
+  const headerLabel =
+    filters.type !== "all"
+      ? (ENTITY_TYPE_LABELS[filters.type as EntityType] ?? "Directory")
+      : filters.sector
+        ? (SECTOR_SLUG_TO_LABEL[filters.sector] ?? "Directory")
+        : "All Entities";
+
+  return (
+    <div className="grid grid-cols-[220px_1fr] gap-10 max-lg:grid-cols-1 max-lg:gap-6">
+      {/* ── Sticky sidebar ─────────────────────────────── */}
+      <aside
+        className={cn(
+          "sticky self-start py-8 pr-2",
+          "top-[var(--header-h)]",
+          "max-h-[calc(100vh-var(--header-h))] overflow-y-auto scrollbar-none",
+          "max-lg:static max-lg:max-h-none max-lg:py-4 max-lg:pr-0 max-lg:overflow-visible",
+        )}
+        aria-label="Filters"
+      >
+        {/* Search */}
+        <div className="relative mb-7">
+          <SearchIcon />
+          <input
+            type="text"
+            placeholder="Search name, ticker..."
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submitSearch();
+              }
+            }}
+            onBlur={submitSearch}
+            className="input !pl-9 !h-9 !text-[13px]"
+          />
+        </div>
+
+        {/* Type */}
+        <SidebarSectionLabel>Type</SidebarSectionLabel>
+        <ul className="flex flex-col mb-7 -mx-2">
+          {ENTITY_TYPE_FILTERS.map((f) => (
+            <li key={f.value}>
+              <button
+                onClick={() => updateFilter({ type: f.value })}
+                className={cn(
+                  "group w-full text-left px-2 py-1.5 text-[13px] font-display font-semibold cursor-pointer transition-colors duration-[180ms] border-none bg-transparent",
+                  "flex items-center gap-2",
+                  f.value === filters.type
+                    ? "text-fg"
+                    : "text-fg-3 hover:text-fg",
+                )}
+              >
+                <span
+                  className={cn(
+                    "inline-block h-px transition-all duration-[280ms] ease-[cubic-bezier(0.7,0,0.2,1)]",
+                    f.value === filters.type
+                      ? "w-4 bg-fg"
+                      : "w-1.5 bg-fg-3 group-hover:w-3 group-hover:bg-fg",
+                  )}
+                />
+                <span>{f.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        {/* Sectors */}
+        <SidebarSectionLabel>Sectors</SidebarSectionLabel>
+        <ul className="flex flex-col mb-7 -mx-2">
+          {SECTOR_OPTIONS.map((s) => {
+            const active = filters.sector === s.slug;
+            return (
+              <li key={s.slug}>
+                <button
+                  onClick={() =>
+                    updateFilter({ sector: active ? null : s.slug })
+                  }
+                  className={cn(
+                    "w-full text-left px-2 py-1.5 text-[13px] cursor-pointer transition-colors duration-[180ms] border-none bg-transparent",
+                    active
+                      ? "text-fg font-display font-semibold"
+                      : "text-fg-3 hover:text-fg",
+                  )}
+                >
+                  {s.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Status — Raising toggle */}
+        <SidebarSectionLabel>Status</SidebarSectionLabel>
+        <button
+          onClick={() => updateFilter({ raising: !filters.raising })}
+          role="switch"
+          aria-checked={filters.raising}
+          className={cn(
+            "flex items-center gap-2 px-2 py-1.5 -mx-2 text-[13px] font-display font-semibold cursor-pointer transition-colors border-none bg-transparent w-full text-left",
+            filters.raising ? "text-fg" : "text-fg-3 hover:text-fg",
+          )}
+        >
+          <span
+            className={cn(
+              "relative inline-block w-7 h-[16px] rounded-full transition-colors duration-200 shrink-0",
+              filters.raising ? "bg-brand" : "bg-border",
+            )}
+          >
+            <span
+              className={cn(
+                "absolute top-[2px] left-[2px] w-[12px] h-[12px] rounded-full bg-[var(--white)] shadow-sm transition-transform duration-200",
+                filters.raising ? "translate-x-[12px]" : "translate-x-0",
+              )}
+            />
+          </span>
+          Actively Raising
+        </button>
+
+        {hasFilters && (
+          <button
+            onClick={clearAll}
+            className="mt-6 text-[11px] uppercase tracking-[0.12em] font-display font-bold text-fg-3 hover:text-brand cursor-pointer bg-transparent border-none px-2"
+          >
+            Clear all
+          </button>
+        )}
+      </aside>
+
+      {/* ── Content column ─────────────────────────────── */}
+      <div className="min-w-0">
+        {/* Page header */}
+        <header className="pt-8 pb-6 border-b border-fg flex items-end justify-between gap-6">
+          <div>
+            <p className="font-display font-bold text-[11px] tracking-[0.18em] uppercase text-fg-3 mb-2">
+              Directory
+            </p>
+            <h1 className="font-display font-extrabold text-3xl tracking-tight leading-none">
+              {headerLabel}
+            </h1>
+          </div>
+
+          <div className="flex items-center gap-4 pb-1">
+            <span className="text-[11px] text-fg-3 font-mono whitespace-nowrap">
+              {props.mode === "filtered"
+                ? `${props.total} results`
+                : `${props.sections.reduce((sum, s) => sum + s.total, 0)} entities`}
+            </span>
+          </div>
+        </header>
+
+        {/* Active filter chips */}
+        {hasFilters && (
+          <div className="flex flex-wrap items-center gap-2 mt-4">
+            <span className="text-[10px] uppercase tracking-[0.12em] font-display font-bold text-fg-3">
+              Filtering by
+            </span>
+            {filters.q && (
+              <Chip
+                label={`"${filters.q}"`}
+                onClear={() => {
+                  setSearchDraft("");
+                  updateFilter({ q: "" });
+                }}
+              />
+            )}
+            {filters.type !== "all" && (
+              <Chip
+                label={
+                  ENTITY_TYPE_LABELS[filters.type as EntityType] ?? filters.type
+                }
+                onClear={() => updateFilter({ type: "all" })}
+              />
+            )}
+            {filters.sector && (
+              <Chip
+                label={SECTOR_SLUG_TO_LABEL[filters.sector] ?? filters.sector}
+                onClear={() => updateFilter({ sector: null })}
+              />
+            )}
+            {filters.raising && (
+              <Chip
+                label="Actively Raising"
+                onClear={() => updateFilter({ raising: false })}
+              />
+            )}
+          </div>
+        )}
+
+        {/* Results */}
+        <div className="mt-7">
+          {props.mode === "sections" ? (
+            <SectionsView
+              sections={props.sections}
+              onSeeAll={(t) => updateFilter({ type: t })}
+            />
+          ) : (
+            <FilteredView
+              items={props.items}
+              total={props.total}
+              page={props.page}
+              pageSize={props.pageSize}
+              onClear={clearAll}
+              onPage={goToPage}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Sub-components ──────────────────────────────────── */
+
+function SectionsView({
+  sections,
+  onSeeAll,
 }: {
-  value: string | null;
-  onChange: (value: string | null) => void;
-  options: readonly string[];
+  sections: Array<{ type: EntityType; items: MockEntity[]; total: number }>;
+  onSeeAll: (type: EntityType) => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top: number; left: number; minWidth: number } | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const panelRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div className="flex flex-col gap-5">
+      {TYPE_ORDER.map(({ variant, label }) => {
+        const section = sections.find((s) => s.type === variant);
+        if (!section || section.total === 0) return null;
+        const hasMore = section.total > section.items.length;
 
-  /* Recompute panel position any time it opens or the viewport changes */
-  useEffect(() => {
-    if (!open) {
-      setPos(null);
-      return;
-    }
-    const update = () => {
-      const el = triggerRef.current;
-      if (!el) return;
-      const r = el.getBoundingClientRect();
-      setPos({ top: r.bottom + 6, left: r.left, minWidth: Math.max(r.width, 220) });
-    };
-    update();
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
-    return () => {
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
-    };
-  }, [open]);
+        return (
+          <div key={variant} className="mt-4">
+            <div className="flex items-center justify-between py-2 border-b border-border-s mb-5 mt-6 sticky top-[var(--header-h)] z-10 bg-[var(--bg)]">
+              <button
+                onClick={() => onSeeAll(variant)}
+                className="font-display font-extrabold text-xl tracking-tight text-fg cursor-pointer bg-transparent border-none p-0 hover:text-brand transition-colors"
+              >
+                {label}
+                <span className="text-fg-3 font-normal text-base ml-2">
+                  {section.total}
+                </span>
+              </button>
+              {hasMore && (
+                <button
+                  onClick={() => onSeeAll(variant)}
+                  className="text-sm font-semibold text-brand-l hover:text-brand cursor-pointer bg-transparent border-none transition-colors font-display"
+                >
+                  View all →
+                </button>
+              )}
+            </div>
 
-  /* Click-outside + Escape */
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      const t = e.target as Node;
-      if (
-        triggerRef.current && !triggerRef.current.contains(t) &&
-        panelRef.current && !panelRef.current.contains(t)
-      ) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", onDoc);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDoc);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+            <div className="grid grid-cols-4 gap-4 max-md:grid-cols-1 max-lg:grid-cols-2 max-xl:grid-cols-3">
+              {section.items.map((entity) => (
+                <EntityCard key={entity.slug} entity={entity} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
-  const label = value ?? "All Sectors";
-  const active = !!value;
+function FilteredView({
+  items,
+  total,
+  page,
+  pageSize,
+  onClear,
+  onPage,
+}: {
+  items: MockEntity[];
+  total: number;
+  page: number;
+  pageSize: number;
+  onClear: () => void;
+  onPage: (p: number) => void;
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="py-20 text-center">
+        <div className="w-12 h-12 rounded-[var(--card-r)] bg-surface grid place-items-center mx-auto mb-4">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-fg-3"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+        </div>
+        <p className="font-display font-bold text-base mb-1">
+          No entities found
+        </p>
+        <p className="text-sm text-fg-3 mb-5">
+          Try adjusting your filters or search a different term.
+        </p>
+        <button onClick={onClear} className="btn btn-secondary text-sm">
+          Clear Filters
+        </button>
+      </div>
+    );
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   return (
     <>
-      <button
-        type="button"
-        ref={triggerRef}
-        onClick={() => setOpen((v) => !v)}
-        className={cn(
-          "flex items-center gap-2 px-3 py-1.5 rounded-[var(--btn-r)] border text-sm font-display font-semibold cursor-pointer transition-all duration-[200ms] whitespace-nowrap",
-          active
-            ? "border-transparent bg-brand-m text-brand"
-            : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l",
-        )}
-      >
-        <span>{label}</span>
-        <svg
-          className={cn(
-            "transition-transform duration-200",
-            open && "rotate-180",
-          )}
-          width="12"
-          height="12"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
-      </button>
+      <div className="grid grid-cols-4 gap-4 max-md:grid-cols-1 max-lg:grid-cols-2 max-xl:grid-cols-3">
+        {items.map((entity) => (
+          <EntityCard key={entity.slug} entity={entity} />
+        ))}
+      </div>
 
-      {open && pos && (
-        <div
-          ref={panelRef}
-          style={{ position: "fixed", top: pos.top, left: pos.left, minWidth: pos.minWidth }}
-          className="z-[100] py-1 rounded-[var(--card-r)] border border-border bg-[var(--white)] shadow-lg max-h-[320px] overflow-y-auto scrollbar-none"
-        >
-          <button
-            type="button"
-            onClick={() => {
-              onChange(null);
-              setOpen(false);
-            }}
-            className={cn(
-              "flex items-center w-full text-left px-3 py-2 text-sm font-medium cursor-pointer transition-colors border-none",
-              !active
-                ? "bg-brand-m text-brand font-semibold"
-                : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg",
-            )}
-          >
-            All Sectors
-          </button>
-          <div className="h-px bg-border-s my-1" />
-          {options.map((s) => (
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-10 py-4 border-t border-border-s">
+          <span className="text-xs text-fg-3 font-mono">
+            Page {page} of {totalPages}
+          </span>
+          <div className="flex items-center gap-2">
             <button
-              key={s}
-              type="button"
-              onClick={() => {
-                onChange(s);
-                setOpen(false);
-              }}
-              className={cn(
-                "flex items-center gap-2 w-full text-left px-3 py-2 text-sm font-medium cursor-pointer transition-colors border-none",
-                value === s
-                  ? "bg-brand-m text-brand font-semibold"
-                  : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg",
-              )}
+              onClick={() => onPage(page - 1)}
+              disabled={page <= 1}
+              className="px-3 py-1.5 rounded-[var(--btn-r)] border border-border bg-[var(--white)] text-sm font-display font-semibold text-fg-2 hover:border-brand-l disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors"
             >
-              <span
-                className={cn(
-                  "w-1.5 h-1.5 rounded-full shrink-0 transition-colors",
-                  value === s ? "bg-brand" : "bg-fg-3",
-                )}
-              />
-              {s}
+              ← Prev
             </button>
-          ))}
+            <button
+              onClick={() => onPage(page + 1)}
+              disabled={page >= totalPages}
+              className="px-3 py-1.5 rounded-[var(--btn-r)] border border-border bg-[var(--white)] text-sm font-display font-semibold text-fg-2 hover:border-brand-l disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors"
+            >
+              Next →
+            </button>
+          </div>
         </div>
       )}
     </>
   );
 }
 
-/* ── Search icon ─────────────────────────── */
+function Chip({ label, onClear }: { label: string; onClear: () => void }) {
+  return (
+    <span className="flex items-center gap-1.5 text-xs font-medium text-brand bg-brand-m px-2.5 py-1 rounded-[var(--btn-r)]">
+      {label}
+      <button
+        onClick={onClear}
+        className="text-brand hover:text-brand-h cursor-pointer bg-transparent border-none p-0 text-xs font-bold"
+        aria-label={`Remove ${label} filter`}
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+function SidebarSectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="font-display font-bold text-[10px] tracking-[0.18em] uppercase text-fg-3 mb-2 pb-2 border-b border-border-s">
+      {children}
+    </p>
+  );
+}
 
 function SearchIcon() {
   return (
     <svg
       className="absolute left-3 top-1/2 -translate-y-1/2 text-fg-3 pointer-events-none"
-      width="16"
-      height="16"
+      width="14"
+      height="14"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -207,259 +493,5 @@ function SearchIcon() {
         d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
       />
     </svg>
-  );
-}
-
-/* ── DirectoryControls ───────────────────── */
-
-interface DirectoryControlsProps {
-  entities: MockEntity[];
-}
-
-export function DirectoryControls({ entities }: DirectoryControlsProps) {
-  const [search, setSearch] = useState("");
-  const [type, setType] = useState("all");
-  const [sector, setSector] = useState<string | null>(null);
-  const [raising, setRaising] = useState(false);
-  const [mounted, setMounted] = useState(false);
-
-  /* Hydrate from URL on mount */
-  useEffect(() => {
-    const init = readParams();
-    setSearch(init.q ?? "");
-    setType(init.type ?? "all");
-    setSector(init.sector ?? null);
-    setRaising(init.raising ?? false);
-    setMounted(true);
-  }, []);
-
-  /* Sync state → URL */
-  useEffect(() => {
-    if (!mounted) return;
-    writeParams({ q: search, type, sector, raising });
-  }, [search, type, sector, raising, mounted]);
-
-  /* Filter logic */
-  const filtered = useMemo(() => {
-    let result = entities;
-
-    if (search) {
-      const q = search.toLowerCase();
-      result = result.filter(
-        (e) =>
-          e.name.toLowerCase().includes(q) ||
-          e.description.toLowerCase().includes(q) ||
-          (e.ticker && e.ticker.toLowerCase().includes(q))
-      );
-    }
-
-    if (type !== "all") {
-      result = result.filter((e) => e.type === type);
-    }
-
-    if (sector) {
-      result = result.filter((e) => e.sector === sector);
-    }
-
-    if (raising) {
-      result = result.filter((e) => e.isRaising);
-    }
-
-    return result;
-  }, [entities, search, type, sector, raising]);
-
-  const total = filtered.length;
-  const hasFilters = !!search || type !== "all" || !!sector || raising;
-
-  const clearAll = useCallback(() => {
-    setSearch("");
-    setType("all");
-    setSector(null);
-    setRaising(false);
-  }, []);
-
-  const handleTypeClick = useCallback((variant: string) => {
-    setType(variant);
-    window.scrollTo({ top: 0 });
-  }, []);
-
-  /* Grouped by type for section view */
-  const grouped = useMemo(() => {
-    const map = new Map<string, MockEntity[]>();
-    for (const entity of filtered) {
-      const key = entity.type;
-      if (!map.has(key)) map.set(key, []);
-      map.get(key)!.push(entity);
-    }
-    return map;
-  }, [filtered]);
-
-  return (
-    <>
-      {/* Page title — dynamic */}
-      <div className="pt-8 pb-6">
-        <div className="flex items-center gap-3">
-          <h1 className="font-display font-extrabold text-2xl tracking-tight">
-            {type !== "all"
-              ? ENTITY_TYPE_LABELS[type as keyof typeof ENTITY_TYPE_LABELS] ?? "Directory"
-              : "All Entities"}
-          </h1>
-          {type !== "all" && (
-            <button
-              onClick={() => setType("all")}
-              className="font-display font-semibold text-sm text-fg-3 hover:text-brand cursor-pointer bg-transparent border-none leading-none mt-px"
-            >
-              ← All
-            </button>
-          )}
-        </div>
-        <p className="text-base text-fg-2 mt-1">
-          Mongolia&apos;s capital markets companies, projects, and service providers
-        </p>
-      </div>
-
-      {/* Inline filter bar — single row */}
-      <div className="flex items-center gap-2 mb-6 overflow-x-auto scrollbar-none -mx-1 px-1">
-          {/* Type tabs */}
-          {ENTITY_TYPE_FILTERS.map((f) => (
-            <button
-              key={f.value}
-              onClick={() => { setType(f.value); window.scrollTo({ top: 0 }); }}
-              className={cn(
-                "px-3 py-1.5 rounded-[var(--btn-r)] text-sm font-display font-semibold whitespace-nowrap transition-all border border-transparent cursor-pointer shrink-0",
-                type === f.value
-                  ? "bg-brand-m text-brand"
-                  : "text-fg-2 hover:text-fg hover:bg-surface",
-              )}
-            >
-              {f.label}
-            </button>
-          ))}
-
-          {/* Divider */}
-          <div className="w-px h-5 bg-border-s mx-1 shrink-0" />
-
-          {/* Sector dropdown (custom, styled) */}
-          <div className="shrink-0">
-            <SectorDropdown value={sector} onChange={setSector} options={SECTOR_LIST} />
-          </div>
-
-          {/* Raising toggle */}
-          <button
-            onClick={() => setRaising(!raising)}
-            role="switch"
-            aria-checked={raising}
-            className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-[var(--btn-r)] border text-sm font-display font-semibold cursor-pointer transition-all duration-[200ms] whitespace-nowrap shrink-0",
-              raising
-                ? "border-transparent bg-brand-m text-brand"
-                : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l",
-            )}
-          >
-            <span
-              className={cn(
-                "relative inline-block w-8 h-[18px] rounded-full transition-colors duration-200 shrink-0",
-                raising ? "bg-brand" : "bg-border",
-              )}
-            >
-              <span
-                className={cn(
-                  "absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-[var(--white)] shadow-sm transition-transform duration-200",
-                  raising ? "translate-x-[14px]" : "translate-x-0",
-                )}
-              />
-            </span>
-            Actively Raising
-          </button>
-
-          {hasFilters && (
-            <button
-              onClick={clearAll}
-              className="text-xs font-display font-semibold text-fg-3 hover:text-brand cursor-pointer bg-transparent border-none px-2 whitespace-nowrap shrink-0"
-            >
-              Clear all
-            </button>
-          )}
-
-          {/* Spacer pushes search + count to the right */}
-          <div className="flex-1" />
-
-          <div className="relative w-[240px] shrink-0 max-md:w-[180px]">
-            <SearchIcon />
-            <input
-              type="text"
-              placeholder="Search by name, ticker..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="input !pl-9"
-            />
-          </div>
-          <span className="text-xs text-fg-3 font-mono whitespace-nowrap shrink-0">{total} results</span>
-      </div>
-
-      {/* Content */}
-      {filtered.length === 0 ? (
-        <div className="py-20 text-center">
-          <div className="w-12 h-12 rounded-[var(--card-r)] bg-surface grid place-items-center mx-auto mb-4">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" className="text-fg-3">
-              <circle cx="11" cy="11" r="8" />
-              <path d="m21 21-4.3-4.3" />
-            </svg>
-          </div>
-          <p className="font-display font-bold text-base mb-1">No entities found</p>
-          <p className="text-sm text-fg-3 mb-5">Try adjusting your filters or search a different term.</p>
-          <button onClick={clearAll} className="btn btn-secondary text-sm">
-            Clear Filters
-          </button>
-        </div>
-      ) : type !== "all" || sector || raising || search ? (
-        /* Filtered view — flat grid */
-        <div className="grid grid-cols-4 gap-4 max-md:grid-cols-1 max-lg:grid-cols-2 max-xl:grid-cols-3">
-          {filtered.map((entity) => (
-            <EntityCard key={entity.slug} entity={entity} />
-          ))}
-        </div>
-      ) : (
-        /* Default view — grouped by type with section headers */
-        <div className="flex flex-col gap-5">
-          {TYPE_ORDER.map(({ variant, label }) => {
-            const items = grouped.get(variant);
-            if (!items || items.length === 0) return null;
-
-            const preview = items.slice(0, SECTION_PREVIEW);
-            const hasMore = items.length > SECTION_PREVIEW;
-
-            return (
-              <div key={variant} className="mt-4">
-                <div className="flex items-center justify-between py-2 border-b border-border-s mb-5 mt-6 sticky top-[var(--header-h)] z-10 bg-[var(--bg)]">
-                  <button
-                    onClick={() => handleTypeClick(variant)}
-                    className="font-display font-extrabold text-xl tracking-tight text-fg cursor-pointer bg-transparent border-none p-0 hover:text-brand transition-colors"
-                  >
-                    {label}
-                    <span className="text-fg-3 font-normal text-base ml-2">{items.length}</span>
-                  </button>
-                  {hasMore && (
-                    <button
-                      onClick={() => handleTypeClick(variant)}
-                      className="text-sm font-semibold text-brand-l hover:text-brand cursor-pointer bg-transparent border-none transition-colors font-display"
-                    >
-                      View all →
-                    </button>
-                  )}
-                </div>
-
-                <div className="grid grid-cols-4 gap-4 max-md:grid-cols-1 max-lg:grid-cols-2 max-xl:grid-cols-3">
-                  {preview.map((entity) => (
-                    <EntityCard key={entity.slug} entity={entity} />
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-    </>
   );
 }

--- a/app/directory/directory-controls.tsx
+++ b/app/directory/directory-controls.tsx
@@ -216,21 +216,12 @@ interface DirectoryControlsProps {
   entities: MockEntity[];
 }
 
-type LayoutVariant = "v1" | "v2";
-
-const LAYOUT_OPTIONS: { value: LayoutVariant; label: string }[] = [
-  { value: "v1", label: "V1 — Drawer" },
-  { value: "v2", label: "V2 — Inline Filters" },
-];
-
 export function DirectoryControls({ entities }: DirectoryControlsProps) {
   const [search, setSearch] = useState("");
   const [type, setType] = useState("all");
   const [sector, setSector] = useState<string | null>(null);
   const [raising, setRaising] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
-  const [layout, setLayout] = useState<LayoutVariant>("v1");
 
   /* Hydrate from URL on mount */
   useEffect(() => {
@@ -247,12 +238,6 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
     if (!mounted) return;
     writeParams({ q: search, type, sector, raising });
   }, [search, type, sector, raising, mounted]);
-
-  /* Lock body scroll when drawer open */
-  useEffect(() => {
-    document.body.style.overflow = drawerOpen ? "hidden" : "";
-    return () => { document.body.style.overflow = ""; };
-  }, [drawerOpen]);
 
   /* Filter logic */
   const filtered = useMemo(() => {
@@ -285,7 +270,6 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
 
   const total = filtered.length;
   const hasFilters = !!search || type !== "all" || !!sector || raising;
-  const activeCount = (type !== "all" ? 1 : 0) + (sector ? 1 : 0) + (raising ? 1 : 0);
 
   const clearAll = useCallback(() => {
     setSearch("");
@@ -312,104 +296,6 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
 
   return (
     <>
-      {/* Slide-in drawer + backdrop (V1 only) */}
-      {layout === "v1" && drawerOpen && (
-        <div
-          className="fixed inset-0 z-[60] bg-black/30"
-          onClick={() => setDrawerOpen(false)}
-        />
-      )}
-      <div
-        className={cn(
-          "fixed top-0 left-0 z-[61] h-full w-[340px] max-w-[85vw] bg-[var(--white)] border-r border-border shadow-xl",
-          "flex flex-col",
-          "transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
-          layout === "v1" && drawerOpen ? "translate-x-0" : "-translate-x-full"
-        )}
-      >
-        <div className="flex items-center justify-between px-5 py-4 border-b border-border-s shrink-0">
-          <span className="font-display font-bold text-base">Filters</span>
-          <button
-            onClick={() => setDrawerOpen(false)}
-            className="w-8 h-8 rounded-[var(--btn-r)] grid place-items-center cursor-pointer border-none bg-transparent text-fg-3 hover:bg-surface hover:text-fg transition-colors"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto scrollbar-none p-5">
-          <span className="font-display font-bold text-xs uppercase tracking-[0.08em] text-fg-3 mb-3 block">Type</span>
-          <div className="flex flex-col gap-0.5 mb-8">
-            {ENTITY_TYPE_FILTERS.map((f) => (
-              <button
-                key={f.value}
-                onClick={() => { setType(f.value); }}
-                className={cn(
-                  "text-left px-3 py-2 rounded-[var(--btn-r)] text-sm font-medium cursor-pointer transition-all duration-[200ms] border-none",
-                  f.value === type
-                    ? "bg-brand-m text-brand font-semibold"
-                    : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg"
-                )}
-              >
-                {f.label}
-              </button>
-            ))}
-          </div>
-
-          <span className="font-display font-bold text-xs uppercase tracking-[0.08em] text-fg-3 mb-3 block">Sector</span>
-          <div className="flex flex-col gap-0.5 mb-8">
-            {SECTOR_LIST.map((s) => (
-              <button
-                key={s}
-                onClick={() => { setSector(sector === s ? null : s); }}
-                className={cn(
-                  "flex items-center gap-2 text-left px-3 py-2 rounded-[var(--btn-r)] text-sm font-medium cursor-pointer transition-all duration-[200ms] border-none",
-                  sector === s
-                    ? "bg-brand-m text-brand font-semibold"
-                    : "bg-transparent text-fg-2 hover:text-brand"
-                )}
-              >
-                <span className={cn(
-                  "w-1.5 h-1.5 rounded-full shrink-0 transition-colors",
-                  sector === s ? "bg-brand" : "bg-fg-3"
-                )} />
-                {s}
-              </button>
-            ))}
-          </div>
-
-          <span className="font-display font-bold text-xs uppercase tracking-[0.08em] text-fg-3 mb-3 block">Status</span>
-          <button
-            onClick={() => setRaising(!raising)}
-            className={cn(
-              "flex items-center gap-2 text-left px-3 py-2 rounded-[var(--btn-r)] text-sm font-medium cursor-pointer transition-all duration-[200ms] border-none w-full",
-              raising
-                ? "bg-signal-m text-signal-h font-semibold"
-                : "bg-transparent text-fg-2 hover:bg-surface hover:text-fg"
-            )}
-          >
-            <span className={cn(
-              "w-1.5 h-1.5 rounded-full shrink-0 transition-colors",
-              raising ? "bg-signal" : "bg-fg-3"
-            )} />
-            Actively Raising
-          </button>
-        </div>
-
-        {hasFilters && (
-          <div className="px-5 py-4 border-t border-border-s shrink-0">
-            <button
-              onClick={clearAll}
-              className="btn btn-secondary w-full text-sm"
-            >
-              Clear all filters
-            </button>
-          </div>
-        )}
-      </div>
-
       {/* Page title — dynamic */}
       <div className="pt-8 pb-6">
         <div className="flex items-center gap-3">
@@ -432,72 +318,8 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
         </p>
       </div>
 
-      {/* ── V1: drawer-trigger top bar ─────────────────── */}
-      {layout === "v1" && (
-        <div className="flex items-center justify-between gap-4 mb-6 flex-wrap">
-          <div className="flex items-center gap-3 flex-wrap">
-            <button
-              onClick={() => setDrawerOpen(true)}
-              className={cn(
-                "flex items-center gap-2 px-3 py-1.5 rounded-[var(--btn-r)] border text-sm font-display font-semibold cursor-pointer transition-all duration-[200ms]",
-                hasFilters
-                  ? "border-transparent bg-brand-m text-brand"
-                  : "border-border bg-[var(--white)] text-fg-2 hover:border-brand-l"
-              )}
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
-                <line x1="4" y1="6" x2="20" y2="6" />
-                <line x1="4" y1="12" x2="14" y2="12" />
-                <line x1="4" y1="18" x2="10" y2="18" />
-              </svg>
-              Filters
-              {activeCount > 0 && (
-                <span className="w-5 h-5 rounded-full bg-brand text-white text-[10px] font-bold grid place-items-center">
-                  {activeCount}
-                </span>
-              )}
-            </button>
-
-            {type !== "all" && (
-              <span className="flex items-center gap-1.5 text-xs font-medium text-brand bg-brand-m px-2.5 py-1 rounded-[var(--btn-r)]">
-                {ENTITY_TYPE_LABELS[type as keyof typeof ENTITY_TYPE_LABELS]}
-                <button onClick={() => setType("all")} className="text-brand hover:text-brand-h cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
-              </span>
-            )}
-            {sector && (
-              <span className="flex items-center gap-1.5 text-xs font-medium text-brand bg-brand-m px-2.5 py-1 rounded-[var(--btn-r)]">
-                {sector}
-                <button onClick={() => setSector(null)} className="text-brand hover:text-brand-h cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
-              </span>
-            )}
-            {raising && (
-              <span className="flex items-center gap-1.5 text-xs font-medium text-signal-h bg-signal-m px-2.5 py-1 rounded-[var(--btn-r)]">
-                <span className="w-1.5 h-1.5 rounded-full bg-signal" />
-                Actively Raising
-                <button onClick={() => setRaising(false)} className="text-signal-h hover:text-signal cursor-pointer bg-transparent border-none p-0 text-xs font-bold">×</button>
-              </span>
-            )}
-          </div>
-
-          <div className="flex items-center gap-3">
-            <div className="relative w-[280px] max-md:w-full">
-              <SearchIcon />
-              <input
-                type="text"
-                placeholder="Search by name, ticker..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="input !pl-9"
-              />
-            </div>
-            <span className="text-xs text-fg-3 font-mono whitespace-nowrap">{total} results</span>
-          </div>
-        </div>
-      )}
-
-      {/* ── V2: inline filter bar — single row ── */}
-      {layout === "v2" && (
-        <div className="flex items-center gap-2 mb-6 overflow-x-auto scrollbar-none -mx-1 px-1">
+      {/* Inline filter bar — single row */}
+      <div className="flex items-center gap-2 mb-6 overflow-x-auto scrollbar-none -mx-1 px-1">
           {/* Type tabs */}
           {ENTITY_TYPE_FILTERS.map((f) => (
             <button
@@ -573,8 +395,7 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
             />
           </div>
           <span className="text-xs text-fg-3 font-mono whitespace-nowrap shrink-0">{total} results</span>
-        </div>
-      )}
+      </div>
 
       {/* Content */}
       {filtered.length === 0 ? (
@@ -639,23 +460,6 @@ export function DirectoryControls({ entities }: DirectoryControlsProps) {
         </div>
       )}
 
-      {/* Floating variant switcher (bottom-center) */}
-      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 p-1 rounded-[var(--btn-r)] border border-border bg-[var(--white)] shadow-lg">
-        {LAYOUT_OPTIONS.map((opt) => (
-          <button
-            key={opt.value}
-            onClick={() => setLayout(opt.value)}
-            className={cn(
-              "px-3 py-1.5 rounded-[var(--btn-r)] text-xs font-display font-semibold cursor-pointer transition-all duration-[200ms] border-none",
-              layout === opt.value
-                ? "bg-brand text-white"
-                : "bg-transparent text-fg-2 hover:text-brand",
-            )}
-          >
-            {opt.label}
-          </button>
-        ))}
-      </div>
     </>
   );
 }

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -2,6 +2,11 @@ import type { Metadata } from "next";
 import { DirectoryControls } from "./directory-controls";
 import { apiGet } from "@/app/lib/api";
 import { adaptEntityListItem } from "@/app/lib/api-adapters";
+import {
+  ENTITY_TYPE_TO_BACKEND,
+  type EntityType,
+  type MockEntity,
+} from "@/app/lib/mock-data";
 
 export const metadata: Metadata = {
   title: "Directory — MarketIQ",
@@ -11,21 +16,113 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
-export default async function DirectoryPage() {
-  let entities: ReturnType<typeof adaptEntityListItem>[] = [];
+const PAGE_SIZE = 24;
+const SECTION_PREVIEW = 8;
+const SECTION_TYPES: EntityType[] = [
+  "public_company",
+  "private_company",
+  "project",
+  "service_provider",
+];
+
+interface PageProps {
+  searchParams: Promise<{
+    q?: string;
+    type?: string;
+    sector?: string;
+    raising?: string;
+    page?: string;
+  }>;
+}
+
+export default async function DirectoryPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const q = params.q?.trim() || undefined;
+  const type =
+    params.type && params.type !== "all" ? (params.type as EntityType) : undefined;
+  const sector = params.sector || undefined;
+  const raising = params.raising === "1";
+  const page = Math.max(1, Number(params.page) || 1);
+
+  const hasFilters = !!(q || type || sector || raising);
+  const filterState = {
+    q: q ?? "",
+    type: type ?? "all",
+    sector: sector ?? null,
+    raising,
+  };
+
+  if (!hasFilters) {
+    // Default landing — fetch each type's first slice in parallel for the
+    // section preview view.
+    const sections = await Promise.all(
+      SECTION_TYPES.map(async (t) => {
+        try {
+          const res = await apiGet("/api/entities", {
+            query: {
+              entityType: ENTITY_TYPE_TO_BACKEND[t],
+              limit: SECTION_PREVIEW,
+              offset: 0,
+            },
+            next: { revalidate: 60, tags: ["entities"] },
+          });
+          return {
+            type: t,
+            items: res.items.map(adaptEntityListItem),
+            total: res.total,
+          };
+        } catch (err) {
+          console.error(`[directory] section ${t} fetch failed:`, err);
+          return { type: t, items: [] as MockEntity[], total: 0 };
+        }
+      }),
+    );
+
+    return (
+      <div className="max-w-[var(--content-max)] mx-auto px-6 w-full">
+        <DirectoryControls
+          mode="sections"
+          sections={sections}
+          filters={filterState}
+        />
+      </div>
+    );
+  }
+
+  // Filtered view — single paginated fetch.
+  let items: MockEntity[] = [];
+  let total = 0;
   try {
     const res = await apiGet("/api/entities", {
-      query: { limit: 100, offset: 0 },
+      query: {
+        q,
+        entityType: type ? ENTITY_TYPE_TO_BACKEND[type] : undefined,
+        sectorSlug: sector,
+        limit: PAGE_SIZE,
+        offset: (page - 1) * PAGE_SIZE,
+      },
       next: { revalidate: 60, tags: ["entities"] },
     });
-    entities = res.items.map(adaptEntityListItem);
+    items = res.items.map(adaptEntityListItem);
+    total = res.total;
+    // `raising` isn't a backend filter yet — narrow the page locally.
+    if (raising) {
+      items = items.filter((e) => e.isRaising);
+    }
   } catch (err) {
-    console.error("[directory] API fetch failed:", err);
+    console.error("[directory] filtered fetch failed:", err);
   }
 
   return (
     <div className="max-w-[var(--content-max)] mx-auto px-6 w-full">
-      <DirectoryControls entities={entities} />
+      <DirectoryControls
+        mode="filtered"
+        items={items}
+        total={total}
+        page={page}
+        pageSize={PAGE_SIZE}
+        filters={filterState}
+      />
     </div>
   );
 }

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -205,6 +205,7 @@ export default async function EventDetailPage({ params }: PageProps) {
         >
           {!isPast && (
             <RegistrationForm
+              slug={event.slug}
               eventTitle={event.shortName ?? event.title}
               ticketPrice={event.ticketPrice}
               registrationDeadline={event.registrationDeadline}

--- a/app/feed/[id]/page.tsx
+++ b/app/feed/[id]/page.tsx
@@ -6,6 +6,7 @@ import {
   MOCK_ENTITIES,
   NEWS_CATEGORY_COLORS,
   NEWS_CATEGORY_LABELS,
+  type MockNewsItem,
 } from "@/app/lib/mock-data";
 import { NewsItemCard } from "@/app/components/feed/news-item-card";
 import { cn } from "@/app/lib/cn";
@@ -14,9 +15,99 @@ interface PageProps {
   params: Promise<{ id: string }>;
 }
 
+interface NewsDetailDto {
+  id: string;
+  title: string;
+  url?: string;
+  source: string;
+  publishedAt: string;
+  signalScore?: number;
+  signalCategory?: string;
+  isIncludedInBrief?: boolean;
+  summary?: string;
+  whyItMatters?: string;
+  resolvedBody?: string;
+  entities?: { slug: string; name?: string }[];
+}
+
+const NEWS_CATEGORY_MAP: Record<string, MockNewsItem["category"]> = {
+  MARKET: "markets", CORPORATE: "companies", SECTOR: "sectors",
+  POLICY: "policy", DEAL: "deals", MACRO: "macro",
+  market: "markets", corporate: "companies", sector: "sectors",
+  policy: "policy", deal: "deals", macro: "macro",
+};
+
+async function fetchNews(id: string): Promise<MockNewsItem | undefined> {
+  const base = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+  try {
+    const res = await fetch(`${base}/api/news/articles/${encodeURIComponent(id)}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return undefined;
+    const dto = (await res.json()) as NewsDetailDto;
+    const summary =
+      dto.summary?.trim() ||
+      dto.whyItMatters?.trim() ||
+      extractBodyExcerpt(dto.resolvedBody);
+    return {
+      id: dto.id,
+      headline: dto.title,
+      summary: summary || undefined,
+      source: dto.source,
+      sourceUrl: dto.url,
+      publishedAt: dto.publishedAt,
+      category: NEWS_CATEGORY_MAP[dto.signalCategory ?? ""] ?? "markets",
+      topics: [],
+      entitySlugs: (dto.entities ?? [])
+        .map((e) => e.slug)
+        .filter((s): s is string => typeof s === "string"),
+      confidence: typeof dto.signalScore === "number" ? dto.signalScore : 0.7,
+      reviewed: Boolean(dto.isIncludedInBrief),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Pull the first decent paragraph out of the scraped markdown body.
+ * Skips title repeats, nav links, and image markdown — finds the first
+ * meaningful prose chunk (≥120 chars).
+ */
+function extractBodyExcerpt(body: string | undefined, maxChars = 360): string {
+  if (!body) return "";
+  // Drop URL-only lines, headings, list markdown, image refs.
+  const lines = body
+    .split(/\n+/)
+    .map((l) => l.trim())
+    .filter((l) => {
+      if (l.length < 60) return false;
+      if (/^#{1,6}\s/.test(l)) return false;
+      if (/^!\[/.test(l)) return false;
+      if (/^\[.*?\]\(https?:\/\//.test(l)) return false;
+      if (/^https?:\/\//.test(l)) return false;
+      return true;
+    });
+  const first = lines.find((l) => l.length >= 120);
+  if (!first) return "";
+  // Strip markdown link syntax: [text](url) → text, and asterisks/underscores.
+  const clean = first
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (clean.length <= maxChars) return clean;
+  const cut = clean.slice(0, maxChars);
+  const lastStop = Math.max(cut.lastIndexOf(". "), cut.lastIndexOf("! "), cut.lastIndexOf("? "));
+  if (lastStop > maxChars * 0.6) return cut.slice(0, lastStop + 1);
+  const lastSpace = cut.lastIndexOf(" ");
+  return (lastSpace > 0 ? cut.slice(0, lastSpace) : cut) + "…";
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const item = MOCK_NEWS.find((n) => n.id === id);
+  const live = await fetchNews(id);
+  const item = live ?? MOCK_NEWS.find((n) => n.id === id);
   if (!item) return { title: "News Not Found — MarketIQ" };
   return {
     title: `${item.headline} — MarketIQ`,
@@ -24,9 +115,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
+export const dynamic = "force-dynamic";
+
 export default async function NewsDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const item = MOCK_NEWS.find((n) => n.id === id);
+  const live = await fetchNews(id);
+  const item = live ?? MOCK_NEWS.find((n) => n.id === id);
   if (!item) notFound();
 
   const entities = item.entitySlugs

--- a/app/insights/[slug]/content-detail-client.tsx
+++ b/app/insights/[slug]/content-detail-client.tsx
@@ -15,7 +15,7 @@ import { EntityChip } from "@/app/components/content/entity-chip";
 import { ArticleSidebar } from "@/app/components/content/article-sidebar";
 import { PdfBar } from "@/app/components/content/pdf-bar";
 import { PaywallWall } from "@/app/components/content/paywall-wall";
-import { MOCK_ARTICLES, MOCK_CONTRIBUTORS, MOCK_ENTITIES } from "@/app/lib/mock-data";
+import { MOCK_ARTICLES, MOCK_CONTRIBUTORS, MOCK_ENTITIES, type MockArticle } from "@/app/lib/mock-data";
 
 /* ── Badge mapping ─────────────────────── */
 
@@ -69,12 +69,19 @@ function LinkedExcerpt({ text, entities }: { text: string; entities: { name: str
   );
 }
 
-export function ContentDetailClient({ slug }: { slug: string }) {
+export function ContentDetailClient({
+  slug,
+  article: articleProp,
+}: {
+  slug: string;
+  article?: MockArticle;
+}) {
   const [loggedIn, setLoggedIn] = useState(false);
 
   useEffect(() => { window.scrollTo({ top: 0 }); }, [slug]);
 
-  const article = MOCK_ARTICLES.find((a) => a.slug === slug);
+  // Prefer the BFF-fetched article (passed from server); fall back to mocks.
+  const article = articleProp ?? MOCK_ARTICLES.find((a) => a.slug === slug);
   if (!article) return <div className="content-max py-20 text-center text-fg-3">Article not found.</div>;
 
   const badge = BADGE_MAP[article.contentType] ?? { label: "Article", variant: "article" as const };

--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -1,14 +1,64 @@
 import type { Metadata } from "next";
 import { ContentDetailClient } from "./content-detail-client";
+import type { MockArticle } from "@/app/lib/mock-data";
 import { MOCK_ARTICLES } from "@/app/lib/mock-data";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+const CONTENT_TYPE_MAP: Record<string, MockArticle["contentType"]> = {
+  article: "article",
+  "market-brief": "market-brief",
+  "investment-teaser": "investment-teaser",
+  "deal-insight": "deal-insight",
+  "research-report": "research-report",
+  "press-release": "press-release",
+};
+
+interface InsightDetailDto {
+  slug: string;
+  title: string;
+  contentType: string;
+  excerpt?: string;
+  publishedAt?: string;
+  isPremium?: boolean;
+  coverImageUrl?: string;
+  topics?: string[];
+  author?: { name: string };
+  entities?: { slug: string }[];
+}
+
+async function fetchInsight(slug: string): Promise<MockArticle | undefined> {
+  const base = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+  try {
+    const res = await fetch(`${base}/api/insights/${encodeURIComponent(slug)}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return undefined;
+    const dto = (await res.json()) as InsightDetailDto;
+    return {
+      slug: dto.slug,
+      title: dto.title,
+      excerpt: dto.excerpt ?? "",
+      contentType: CONTENT_TYPE_MAP[dto.contentType] ?? "article",
+      topics: dto.topics ?? [],
+      author: dto.author?.name ?? "CMM Research",
+      publishedAt: dto.publishedAt ?? new Date().toISOString(),
+      readTime: 8,
+      isPremium: Boolean(dto.isPremium),
+      entityRefs: (dto.entities ?? []).map((e) => e.slug),
+      coverImage: dto.coverImageUrl,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const article = MOCK_ARTICLES.find((a) => a.slug === slug);
+  const live = await fetchInsight(slug);
+  const article = live ?? MOCK_ARTICLES.find((a) => a.slug === slug);
 
   return {
     title: article ? `${article.title} — MarketIQ` : "Insights — MarketIQ",
@@ -16,8 +66,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
+export const dynamic = "force-dynamic";
+
 export default async function ContentDetailPage({ params }: PageProps) {
   const { slug } = await params;
+  const article = await fetchInsight(slug);
 
-  return <ContentDetailClient slug={slug} />;
+  return <ContentDetailClient slug={slug} article={article} />;
 }

--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { ContentDetailClient } from "./content-detail-client";
 import type { MockArticle } from "@/app/lib/mock-data";
 import { MOCK_ARTICLES } from "@/app/lib/mock-data";
+import { ApiError, apiGet, path } from "@/app/lib/api";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -10,33 +11,20 @@ interface PageProps {
 const CONTENT_TYPE_MAP: Record<string, MockArticle["contentType"]> = {
   article: "article",
   "market-brief": "market-brief",
+  "monthly-update": "market-brief",
   "investment-teaser": "investment-teaser",
   "deal-insight": "deal-insight",
   "research-report": "research-report",
   "press-release": "press-release",
+  "cmm-guide": "research-report",
 };
 
-interface InsightDetailDto {
-  slug: string;
-  title: string;
-  contentType: string;
-  excerpt?: string;
-  publishedAt?: string;
-  isPremium?: boolean;
-  coverImageUrl?: string;
-  topics?: string[];
-  author?: { name: string };
-  entities?: { slug: string }[];
-}
-
 async function fetchInsight(slug: string): Promise<MockArticle | undefined> {
-  const base = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
   try {
-    const res = await fetch(`${base}/api/insights/${encodeURIComponent(slug)}`, {
-      cache: "no-store",
-    });
-    if (!res.ok) return undefined;
-    const dto = (await res.json()) as InsightDetailDto;
+    const dto = await apiGet(
+      path("/api/insights/{slug}", { slug }),
+      { next: { revalidate: 60, tags: [`insight:${slug}`] } },
+    );
     return {
       slug: dto.slug,
       title: dto.title,
@@ -50,7 +38,11 @@ async function fetchInsight(slug: string): Promise<MockArticle | undefined> {
       entityRefs: (dto.entities ?? []).map((e) => e.slug),
       coverImage: dto.coverImageUrl,
     };
-  } catch {
+  } catch (err) {
+    // 404 → fall through to mock fallback. Other errors → log & fall through.
+    if (!(err instanceof ApiError) || err.status !== 404) {
+      console.error("[insight detail] fetch failed:", err);
+    }
     return undefined;
   }
 }

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { InsightsControls } from "./insights-controls";
 import type { Article } from "@/app/components/insights/insights-grid";
-import { MOCK_ARTICLES } from "@/app/lib/mock-data";
 import { apiGet } from "@/app/lib/api";
 import { adaptInsightToArticle } from "@/app/lib/api-adapters";
 
@@ -12,48 +11,6 @@ export const metadata: Metadata = {
 };
 
 export const dynamic = "force-dynamic";
-
-/* ── Map mock contentType → badge variant ── */
-
-const BADGE_MAP: Record<
-  string,
-  {
-    label: string;
-    variant: "research" | "article" | "deal" | "update" | "teaser" | "press";
-  }
-> = {
-  article: { label: "Article", variant: "article" },
-  "market-brief": { label: "Market Brief", variant: "update" },
-  "investment-teaser": { label: "Investment Teaser", variant: "teaser" },
-  "deal-insight": { label: "Deal Insight", variant: "deal" },
-  "research-report": { label: "Research Report", variant: "research" },
-  "press-release": { label: "Press Release", variant: "press" },
-};
-
-const FALLBACK_ARTICLES: Article[] = MOCK_ARTICLES.map((a, i) => ({
-  slug: a.slug,
-  title: a.title,
-  excerpt: a.excerpt,
-  badge: BADGE_MAP[a.contentType] ?? { label: "Article", variant: "article" },
-  author: a.author,
-  date: new Date(a.publishedAt).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }),
-  readTime: `${a.readTime} min read`,
-  topics: a.topics,
-  featured: i === 0,
-  image: a.coverImage ? (
-    <Image
-      src={a.coverImage}
-      alt={a.title}
-      fill
-      className="object-cover"
-      sizes="(max-width: 640px) 100vw, 50vw"
-    />
-  ) : undefined,
-}));
 
 export default async function InsightsPage() {
   let articles: Article[] = [];
@@ -75,10 +32,8 @@ export default async function InsightsPage() {
         />
       ) : undefined,
     }));
-    if (articles.length === 0) articles = FALLBACK_ARTICLES;
   } catch (err) {
-    console.error("[insights] BFF unavailable, using static seed:", err);
-    articles = FALLBACK_ARTICLES;
+    console.error("[insights] BFF fetch failed:", err);
   }
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Plus_Jakarta_Sans, DM_Sans, JetBrains_Mono, Newsreader } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
+import { clerkAppearance } from "./lib/clerk-appearance";
 import "./globals.css";
 import { Header } from "./components/layout/header";
 import { Footer } from "./components/layout/footer";
@@ -43,7 +44,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClerkProvider>
+    <ClerkProvider appearance={clerkAppearance}>
       <html
         lang="en"
         className={`${plusJakarta.variable} ${dmSans.variable} ${jetbrainsMono.variable} ${newsreader.variable} h-full antialiased`}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -2,15 +2,13 @@
  * Tiny typed fetch wrapper around the CMM MarketIQ NestJS API.
  *
  * Uses generated OpenAPI types (`api-types.ts`) for compile-time safety
- * without a runtime client library. Swap to `openapi-fetch` or
- * `@hey-api/openapi-ts` SDK once `@cmm/api-client` package publishing
- * is set up.
+ * without a runtime client library.
  *
- * Usage (server component):
- *   const res = await api('/api/entities', { query: { limit: 24 } });
- *
- * Auth: pass a Bearer token in `token` for protected endpoints. Pull it
- * from Clerk's `auth().getToken()` in server components once Clerk is wired.
+ * Auth: in a server context (Server Component / Route Handler / Server
+ * Action) the Clerk session token is auto-attached as a Bearer header.
+ * Opt out with `{ anonymous: true }` when calling a public endpoint
+ * where you don't want to leak the token. In a client context no token
+ * is attached — client-side calls must go through a server action.
  */
 
 import type { paths } from "./api-types";
@@ -20,6 +18,20 @@ declare const process: { env: { NEXT_PUBLIC_API_URL?: string } };
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+const IS_SERVER = typeof window === "undefined";
+
+async function getClerkToken(): Promise<string | null> {
+  if (!IS_SERVER) return null;
+  try {
+    const { auth } = await import("@clerk/nextjs/server");
+    const session = await auth();
+    return (await session.getToken()) ?? null;
+  } catch {
+    // Outside a request scope (build, scripts) auth() throws — that's fine.
+    return null;
+  }
+}
 
 type Method = "GET" | "POST" | "PATCH" | "DELETE";
 
@@ -52,7 +64,10 @@ type PostResponse<P extends keyof paths> =
       : never;
 
 interface BaseOptions {
+  /** Override the auto-injected Clerk session token. */
   token?: string;
+  /** Skip auto-injecting the Clerk token (use for public endpoints). */
+  anonymous?: boolean;
   /** Next.js fetch cache options. Default: `no-store` for fresh data. */
   cache?: RequestCache;
   /** Next.js revalidation tag/seconds. */
@@ -101,7 +116,17 @@ async function request<T>(
     Accept: "application/json",
   };
   if (init.body !== undefined) headers["Content-Type"] = "application/json";
-  if (init.token) headers["Authorization"] = `Bearer ${init.token}`;
+
+  // Don't auto-inject a token on cacheable requests — Next.js would store
+  // the per-user response in the shared cache. Cacheable = anonymous by
+  // default. Caller can still pass `token` explicitly to override.
+  const isCacheable =
+    (init.cache !== undefined && init.cache !== "no-store") ||
+    init.next?.revalidate !== undefined;
+  const shouldAutoInject = !init.anonymous && !isCacheable;
+  const token =
+    init.token ?? (shouldAutoInject ? await getClerkToken() : null);
+  if (token) headers["Authorization"] = `Bearer ${token}`;
 
   // Next.js augments RequestInit with `next` (revalidate/tags). Cast to any
   // so this file compiles in environments where Next's lib types haven't loaded.
@@ -138,6 +163,7 @@ export async function apiGet<P extends keyof paths>(
     {
       query: options.query as Record<string, unknown> | undefined,
       token: options.token,
+      anonymous: options.anonymous,
       cache: options.cache,
       next: options.next,
     },
@@ -154,6 +180,7 @@ export async function apiPost<P extends keyof paths>(
     {
       body: options.body,
       token: options.token,
+      anonymous: options.anonymous,
       cache: "no-store",
     },
   );

--- a/app/lib/clerk-appearance.ts
+++ b/app/lib/clerk-appearance.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared Clerk appearance config — pulls GrayUI tokens so SignIn / SignUp /
+ * UserButton match the rest of the editorial design (sharp corners,
+ * brand purple, Plus Jakarta + Newsreader, no SaaS rounding).
+ *
+ * Loose-typed (no @clerk/types import) — Clerk's `appearance` prop accepts
+ * the shape structurally, and we get autocomplete via the component props.
+ */
+export const clerkAppearance = {
+  variables: {
+    colorPrimary: "#3E149C",         // --brand
+    colorText: "#0C0A1D",            // --fg
+    colorTextSecondary: "#44415A",   // --fg-2
+    colorBackground: "#FFFFFF",      // --white
+    colorInputBackground: "#FFFFFF",
+    colorInputText: "#0C0A1D",
+    colorDanger: "#DC2626",          // --neg
+    colorSuccess: "#059669",         // --pos
+    colorWarning: "#FCA311",         // --signal
+    colorNeutral: "#7A7793",         // --fg-3
+    fontFamily: "var(--font-plus-jakarta-sans), system-ui, sans-serif",
+    fontFamilyButtons: "var(--font-plus-jakarta-sans), system-ui, sans-serif",
+    borderRadius: "2px",             // --card-r — GrayUI is sharp, no rounding
+    spacingUnit: "1rem",
+  },
+  elements: {
+    rootBox: "mx-auto",
+    card: "shadow-none border border-border-s rounded-[var(--card-r)] bg-[var(--white)]",
+    headerTitle: "font-display font-extrabold tracking-tight text-fg",
+    headerSubtitle: "text-fg-3",
+    socialButtonsBlockButton:
+      "border border-border rounded-[var(--btn-r)] !text-fg hover:bg-surface transition-colors font-display font-semibold",
+    socialButtonsBlockButtonText: "font-display font-semibold",
+    dividerLine: "bg-border-s",
+    dividerText: "text-fg-3 text-[10px] uppercase tracking-[0.18em] font-display font-bold",
+    formFieldLabel: "font-display font-semibold text-[11px] uppercase tracking-[0.08em] text-fg-2",
+    formFieldInput:
+      "border border-border rounded-[var(--btn-r)] bg-[var(--white)] text-fg focus:border-brand focus:ring-0",
+    formButtonPrimary:
+      "bg-brand hover:bg-brand-h text-white rounded-[var(--btn-r)] font-display font-semibold normal-case shadow-none",
+    footerActionText: "text-fg-3",
+    footerActionLink: "text-brand hover:text-brand-h font-display font-semibold no-underline",
+    identityPreview: "border border-border rounded-[var(--btn-r)] bg-surface",
+    identityPreviewText: "text-fg",
+    formFieldInputShowPasswordButton: "text-fg-3 hover:text-fg",
+    formFieldErrorText: "text-neg text-xs",
+    alert: "border border-border rounded-[var(--card-r)]",
+    badge: "rounded-[var(--btn-r)] font-display font-bold uppercase tracking-[0.08em] text-[10px]",
+    userPreviewMainIdentifier: "font-display font-semibold text-fg",
+    userPreviewSecondaryIdentifier: "text-fg-3",
+    userButtonPopoverCard:
+      "shadow-lg border border-border-s rounded-[var(--card-r)] bg-[var(--white)]",
+    userButtonPopoverActionButton:
+      "font-display font-medium text-fg-2 hover:text-fg hover:bg-surface",
+    userButtonPopoverActionButtonText: "font-display font-medium",
+    userButtonPopoverFooter: "border-t border-border-s",
+  },
+  layout: {
+    socialButtonsPlacement: "top",
+    socialButtonsVariant: "blockButton",
+    showOptionalFields: false,
+  },
+};

--- a/app/lib/mock-data.ts
+++ b/app/lib/mock-data.ts
@@ -43,6 +43,36 @@ export const SECTOR_LIST = [
   "Professional Services",
 ] as const;
 
+/** Slug ↔ label pairs. Slugs match `public.sectors` rows on the backend. */
+export const SECTOR_OPTIONS = [
+  { slug: "mining", label: "Mining" },
+  { slug: "financial-services", label: "Financial Services" },
+  { slug: "energy", label: "Energy" },
+  { slug: "tech-media", label: "Technology & Media" },
+  { slug: "real-estate", label: "Real Estate" },
+  { slug: "infrastructure", label: "Infrastructure" },
+  { slug: "consumer-services", label: "Consumer & Services" },
+  { slug: "agriculture", label: "Agriculture" },
+  { slug: "cashmere-textile", label: "Cashmere & Textile" },
+  { slug: "conglomerate-soe", label: "Conglomerate & SOE" },
+  { slug: "healthcare", label: "Healthcare" },
+  { slug: "logistics", label: "Logistics" },
+  { slug: "services", label: "Services" },
+  { slug: "other", label: "Other" },
+] as const;
+
+export const SECTOR_SLUG_TO_LABEL: Record<string, string> = Object.fromEntries(
+  SECTOR_OPTIONS.map((s) => [s.slug, s.label]),
+);
+
+/** Backend uses uppercase enum, frontend uses lowercase. */
+export const ENTITY_TYPE_TO_BACKEND = {
+  public_company: "PUBLIC_COMPANY",
+  private_company: "PRIVATE_COMPANY",
+  project: "PROJECT",
+  service_provider: "SERVICE_PROVIDER",
+} as const satisfies Record<EntityType, string>;
+
 /* ── Rich entity spec (from Entity Fields Master, Apr 23) ── */
 
 export type DataSource = "AI-Sourced" | "AI-Generated" | "CMM Verified" | "CMM Curated" | "Company Submitted";

--- a/app/sign-in/[[...rest]]/page.tsx
+++ b/app/sign-in/[[...rest]]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { SignIn } from "@clerk/nextjs";
+import { clerkAppearance } from "@/app/lib/clerk-appearance";
 
 export const metadata: Metadata = {
   title: "Sign In — MarketIQ",
@@ -9,14 +10,7 @@ export const metadata: Metadata = {
 export default function SignInPage() {
   return (
     <div className="flex-1 flex items-center justify-center px-6 py-20">
-      <SignIn
-        appearance={{
-          elements: {
-            rootBox: "mx-auto",
-            card: "shadow-none border border-border-s rounded-[var(--card-r)]",
-          },
-        }}
-      />
+      <SignIn appearance={clerkAppearance} />
     </div>
   );
 }

--- a/app/sign-up/[[...rest]]/page.tsx
+++ b/app/sign-up/[[...rest]]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { SignUp } from "@clerk/nextjs";
+import { clerkAppearance } from "@/app/lib/clerk-appearance";
 
 export const metadata: Metadata = {
   title: "Create account — MarketIQ",
@@ -9,14 +10,7 @@ export const metadata: Metadata = {
 export default function SignUpPage() {
   return (
     <div className="flex-1 flex items-center justify-center px-6 py-20">
-      <SignUp
-        appearance={{
-          elements: {
-            rootBox: "mx-auto",
-            card: "shadow-none border border-border-s rounded-[var(--card-r)]",
-          },
-        }}
-      />
+      <SignUp appearance={clerkAppearance} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Clerk auto-token in apiGet/apiPost** — server-context calls auto-attach the Clerk session JWT as Bearer; cacheable requests skip auto-inject (would otherwise leak per-user tokens into Next's shared cache). \`{ anonymous: true }\` opts out, \`{ token }\` overrides.
- **Directory rewrite** — searchParams drive backend filtering (q/entityType/sectorSlug/limit/offset). Insights-style sticky sidebar (search → Type list → Sector list → Status toggle). Default landing fires 4 parallel per-type calls for the section preview view; filtered view paginates. Real backend sector slugs from \`public.sectors\` replace the day-one bug where UI labels never matched data.
- **Insights detail** — raw fetch → typed apiGet + ApiError, distinguishes 404 from network failure.
- **Events registration** — real server action via useActionState, posts via apiPost (Clerk-attached), surfaces success/error inline. Verified with a real DB write to \`public.event_registrations\`.

## Test plan

- [x] Directory: filter by sector → backend gets \`?sectorSlug=mining\`, returns 3, UI renders 3
- [x] Directory: section view shows 4 type sections with per-type counts
- [x] Insights detail page loads via apiGet with proper 404 handling
- [x] Event registration POST → real DB row in \`public.event_registrations\`
- [x] Clerk session auto-attaches on server fetches; cacheable calls correctly skip
- [x] Typecheck passes (\`pnpm tsc --noEmit\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)